### PR TITLE
Add GitLab integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/GitLabApiClient"]
 	path = deps/GitLabApiClient
-	url = git@github.com:ap0llo/GitLabApiClient.git
+	url = https://github.com/ap0llo/GitLabApiClient.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/GitLabApiClient"]
+	path = deps/GitLabApiClient
+	url = git@github.com:ap0llo/GitLabApiClient.git

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,89 @@
+# Integrations
+
+While a changelog can be generated from any git repository, "Integrations"
+provide extended features for repositories hosted by any of the supported
+providers.
+
+Currently supported providers are:
+
+- [GitHub](#github)
+- [GitLab](#gitlab)
+
+## Configuring integrations
+
+By default, no integrations are enabled. To specify the integration provider,
+use the using the `changelog:integrations:provider` setting in `changelog.settings.json`:
+
+```json
+{
+    "changelog": {
+        "integrations": {
+            "provider": "GitHub"
+        }
+    }
+}
+```
+
+Allowed values are `none` (default), `GitHub` and `GitLab`
+
+## GitHub
+
+The GitHub integration provides the following features:
+
+- Adds link to the GitHub web site to the commit for every changelog entry
+- Adds link to the GitHub web site to issues and pull requests if they
+  are referenced in footers.<br>
+  The following types of references are recognized:
+  - `#<id>`: Reference to an issue or pull request in the same project,
+    e.g. `#123`
+  - `<user>/<project>#<id>`: Reference to an issue or pull request in a
+    different project, e.g. `ap0llo/changelog#123`
+  - `GH-<id>`: Reference to an issue or pull request in the same project,
+    e.g.`GH-123`
+  
+The GitHub integration should work with both github.com and GitHub Enterprise
+installations. However, it was not yet tested with GitHub Enterprise.
+
+The GitHub server address and the project name are read from the url of the
+*origin* remote in the local git repository.
+
+To access private repositories, an access token must be specified using the
+`--gitHubAccessToken` commandline parameter. Because GitHub has a quite low
+rate limit for unauthenticated API requests, it is recommended to use a access
+token even if you only access public repositories.
+
+## GitLab
+
+The GitLab integration provides the following features:
+
+- Adds link to the GitLab web site to the commit for every changelog entry
+- Adds link to the GitLab web site for references in footers.<br>
+  The following types of references are recognized:
+  - Issues
+    - `#<id>`: Reference to a issue in the same project, e.g. `#123`
+    - `<project>#<id>`: Reference to an issue in a different project in
+      the same namespace, e.g. `<changelog>#123`
+    - `<user>/<project>#<id>`: Reference to an issue in a different project and
+      namespace, e.g. `ap0llo/changelog#123`
+  - Merge Requests
+    - `!<id>`: Reference to a merge request in the same project, e.g. `!123`
+    - `<project>!<id>`: Reference to a merge request in a different project in
+      the same namespace, e.g. `<changelog>!123`
+    - `<user>/<project>!<id>`: Reference to a merge request in a different 
+      project and namespace, e.g. `ap0llo/changelog!123`
+  - Milestones
+    - `%<id>`: Reference to a milestone in the same project, e.g. `%123`
+    - `<project>%<id>`: Reference to a milestone in a different project in
+      the same namespace, e.g. `<changelog>%123`
+    - `<user>/<project>%<id>`: Reference to a milestone request in a different
+      project and namespace, e.g. `ap0llo/changelog%123`
+
+The GitLab integration should work with both gitlab.com and self-hosted
+GitLab installations. However, it was not yet tested with a self-hosted
+GitLab instance.
+
+The address of the GitLab server and the project name are read from the url
+of the *origin* remote in the local git repository.
+
+To access private repositories, an access token must be specified using the
+`--gitLabAccessToken` commandline parameter.

--- a/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
+++ b/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
@@ -53,9 +53,14 @@ namespace Grynwald.ChangeLog.Test.Configuration
 
             yield return TestCase(config => Assert.NotNull(config.Integrations));
             yield return TestCase(config => Assert.Equal(ChangeLogConfiguration.IntegrationProvider.None, config.Integrations.Provider));
+
             yield return TestCase(config => Assert.NotNull(config.Integrations.GitHub));
             yield return TestCase(config => Assert.NotNull(config.Integrations.GitHub.AccessToken));
             yield return TestCase(config => Assert.Empty(config.Integrations.GitHub.AccessToken));
+
+            yield return TestCase(config => Assert.NotNull(config.Integrations.GitLab));
+            yield return TestCase(config => Assert.NotNull(config.Integrations.GitLab.AccessToken));
+            yield return TestCase(config => Assert.Empty(config.Integrations.GitLab.AccessToken));
 
             yield return TestCase(config => Assert.NotNull(config.VersionRange));
             yield return TestCase(config => Assert.Empty(config.VersionRange));
@@ -238,6 +243,20 @@ namespace Grynwald.ChangeLog.Test.Configuration
             Assert.Equal(accessToken, config.Integrations.GitHub.AccessToken);
         }
 
+        [Theory]
+        [InlineData("some-access-token")]
+        public void GitLab_access_token_can_be_set_in_configuration_file(string accessToken)
+        {
+            // ARRANGE
+            PrepareConfiguration("integrations:gitlab:accesstoken", accessToken);
+
+            // ACT 
+            var config = ChangeLogConfigurationLoader.GetConfiguation(m_ConfigurationDirectory);
+
+            // ASSERT
+            Assert.NotNull(config.Integrations.GitLab);
+            Assert.Equal(accessToken, config.Integrations.GitLab.AccessToken);
+        }
 
         private class TestSettingsClass2
         {
@@ -261,6 +280,28 @@ namespace Grynwald.ChangeLog.Test.Configuration
             Assert.Equal("some-other-access-token", config.Integrations.GitHub.AccessToken);
         }
 
+        private class TestSettingsClass3
+        {
+            [ConfigurationValue("changelog:integrations:gitlab:accesstoken")]
+            public string? GitLabAccessToken { get; set; }
+        }
+
+        [Fact]
+        public void Configuration_from_settings_object_can_override_GitLab_access_token()
+        {
+            // ARRANGE
+            PrepareConfiguration("integrations:gitlab:accesstoken", "some-access-token");
+            var settingsObject = new TestSettingsClass3() { GitLabAccessToken = "some-other-access-token" };
+
+            // ACT 
+            var config = ChangeLogConfigurationLoader.GetConfiguation(m_ConfigurationDirectory, settingsObject);
+
+            // ASSERT
+            Assert.NotNull(config.Integrations);
+            Assert.NotNull(config.Integrations.GitLab);
+            Assert.Equal("some-other-access-token", config.Integrations.GitLab.AccessToken);
+        }
+
 
         [Theory]
         [InlineData("[1.2.3,)")]
@@ -278,7 +319,7 @@ namespace Grynwald.ChangeLog.Test.Configuration
         }
 
 
-        private class TestSettingsClass3
+        private class TestSettingsClass4
         {
             [ConfigurationValue("changelog:versionrange")]
             public string? VersionRange { get; set; }
@@ -289,7 +330,7 @@ namespace Grynwald.ChangeLog.Test.Configuration
         {
             // ARRANGE
             PrepareConfiguration("versionRange", "[1.2.3]");
-            var settingsObject = new TestSettingsClass3() { VersionRange = "[4.5.6]" };
+            var settingsObject = new TestSettingsClass4() { VersionRange = "[4.5.6]" };
 
             // ACT 
             var config = ChangeLogConfigurationLoader.GetConfiguation(m_ConfigurationDirectory, settingsObject);

--- a/src/ChangeLog.Test/Integrations/GitHub/GitHubLinkTaskTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitHub/GitHubLinkTaskTest.cs
@@ -159,6 +159,8 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitHub
             m_GitHubCommitsClientMock.Verify(x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(entries.Length));
         }
 
+        //TODO: Run does not add a commit link if commit cannot be found
+
         [Theory]
         [InlineData("#23", 23, "owner", "repo")]
         [InlineData("GH-23", 23, "owner", "repo")]
@@ -385,7 +387,6 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitHub
             m_GitHubIssuesClientMock.Verify(x => x.Get(owner, repo, It.IsAny<int>()), Times.Once);
             m_GitHubPullRequestsClient.Verify(x => x.Get(owner, repo, It.IsAny<int>()), Times.Once);
         }
-
 
         [Theory]
         [InlineData("github.com")]

--- a/src/ChangeLog.Test/Integrations/GitHub/GitHubUrlParserTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitHub/GitHubUrlParserTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Grynwald.ChangeLog.Integrations.GitHub;
 using Xunit;
 
@@ -49,7 +50,7 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitHub
         [InlineData("not-a-url")]
         [InlineData("http://github.com/owner/another-name/repo.git")] // to many segments in the path
         [InlineData("ftp://github.com/owner/repo.git")] // unsupported scheme
-        public void TryParseRemoteUrl_throws_ArgumentException_for_invalid_input(string url)
+        public void TryParseRemoteUrl_returns_false_for_invalid_input(string url)
         {
             Assert.False(GitHubUrlParser.TryParseRemoteUrl(url, out var uri));
         }

--- a/src/ChangeLog.Test/Integrations/GitLab/GitLabClientFactoryTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitLab/GitLabClientFactoryTest.cs
@@ -1,0 +1,58 @@
+﻿using Grynwald.ChangeLog.Configuration;
+using Grynwald.ChangeLog.Integrations.GitLab;
+using Xunit;
+
+namespace Grynwald.ChangeLog.Test.Integrations.GitLab
+{
+    public class GitLabClientFactoryTest
+    {
+        [Theory]
+        [InlineData("gitlab.com", "https://gitlab.com/api/v4/")]
+        [InlineData("example.com", "https://example.com/api/v4/")]
+        public void GetClient_returns_the_expected_client(string hostName, string expectedHostUrl)
+        {
+            // ARRANGE
+            var sut = new GitLabClientFactory(new ChangeLogConfiguration());
+
+            // ACT
+            var client = sut.CreateClient(hostName);
+
+            // ASSERT
+            Assert.Equal(expectedHostUrl, client.HostUrl);
+        }
+
+        [Fact]
+        public void CreateClient_succeeds_if_an_access_token_is_configured()
+        {
+            // ARRANGE
+            var configuration = new ChangeLogConfiguration();
+            configuration.Integrations.GitLab.AccessToken = "00000000000000000000";
+
+            var sut = new GitLabClientFactory(configuration);
+
+            // ACT
+            var client = sut.CreateClient("gitlab.com");
+
+            // ASSERT
+            Assert.NotNull(client);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void CreateClient_succeeds_if_no_access_token_is_configured(string accessToken)
+        {
+            // ARRANGE
+            var configuration = new ChangeLogConfiguration();
+            configuration.Integrations.GitLab.AccessToken = accessToken;
+
+            var sut = new GitLabClientFactory(configuration);
+
+            // ACT
+            var client = sut.CreateClient("gitlab.com");
+
+            // ASSERT
+            Assert.NotNull(client);            
+        }
+    }
+}

--- a/src/ChangeLog.Test/Integrations/GitLab/GitLabLinkTaskTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitLab/GitLabLinkTaskTest.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using GitLabApiClient;
+using GitLabApiClient.Internal.Paths;
+using GitLabApiClient.Models.Commits.Responses;
+using Grynwald.ChangeLog.Git;
+using Grynwald.ChangeLog.Integrations.GitLab;
+using Grynwald.ChangeLog.Model;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Grynwald.ChangeLog.Test.Integrations.GitLab
+{
+    public class GitLabLinkTaskTest : TestBase
+    {
+
+        private readonly ILogger<GitLabLinkTask> m_Logger = NullLogger<GitLabLinkTask>.Instance;
+        private readonly Mock<IGitLabClientFactory> m_ClientFactoryMock;
+        private readonly Mock<IGitLabClient> m_ClientMock;
+        private readonly Mock<ICommitsClient> m_CommitsClientMock;
+        private readonly Mock<IGitRepository> m_RepositoryMock;
+
+        public GitLabLinkTaskTest()
+        {
+            m_CommitsClientMock = new Mock<ICommitsClient>(MockBehavior.Strict);
+
+            m_ClientMock = new Mock<IGitLabClient>(MockBehavior.Strict);
+            m_ClientMock.Setup(x => x.Commits).Returns(m_CommitsClientMock.Object);
+
+            m_ClientFactoryMock = new Mock<IGitLabClientFactory>(MockBehavior.Strict);
+            m_ClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(m_ClientMock.Object);
+
+            m_RepositoryMock = new Mock<IGitRepository>(MockBehavior.Strict);
+        }
+
+        private ProjectId MatchProjectId(string expected)
+        {
+            return It.Is<ProjectId>((ProjectId actual) => actual.ToString() == ((ProjectId)expected).ToString());
+        }
+
+        [Fact]
+        public async Task Run_does_nothing_if_repository_does_not_have_remotes()
+        {
+            // ARRANGE            
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(Enumerable.Empty<GitRemote>());
+
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+            var changeLog = new ApplicationChangeLog();
+
+            // ACT 
+            await sut.RunAsync(changeLog);
+
+            // ASSERT
+            m_ClientFactoryMock.Verify(x => x.CreateClient(It.IsAny<string>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("not-a-url")]
+        [InlineData("http://not-a-gitlab-url.com")]
+        public async Task Run_does_nothing_if_remote_url_cannot_be_parsed(string url)
+        {
+            // ARRANGE            
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(new[] { new GitRemote("origin", url) });
+
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+            var changeLog = new ApplicationChangeLog();
+
+            // ACT 
+            await sut.RunAsync(changeLog);
+
+            // ASSERT
+            m_ClientFactoryMock.Verify(x => x.CreateClient(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Run_adds_a_link_to_all_commits_if_url_can_be_parsed()
+        {
+            // ARRANGE
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(new[] { new GitRemote("origin", "http://gitlab.com/user/repo.git") });
+
+            m_CommitsClientMock
+                .Setup(x => x.GetAsync(MatchProjectId("user/repo"), It.IsAny<string>()))
+                .Returns(
+                    (ProjectId id, string sha) => Task.FromResult(new Commit() { WebUrl = $"https://example.com/{sha}" })
+                );
+
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+
+            var changeLog = new ApplicationChangeLog()
+            {
+                GetSingleVersionChangeLog(
+                    "1.2.3",
+                    null,
+                    GetChangeLogEntry(summary: "Entry1", commit: "01"),
+                    GetChangeLogEntry(summary: "Entry2", commit: "02")
+                ),
+                GetSingleVersionChangeLog(
+                    "4.5.6",
+                    null,
+                    GetChangeLogEntry(summary: "Entry1", commit: "03"),
+                    GetChangeLogEntry(summary: "Entry2", commit: "04")
+                )
+            };
+
+            // ACT 
+            await sut.RunAsync(changeLog);
+
+            // ASSERT
+            var entries = changeLog.ChangeLogs.SelectMany(x => x.AllEntries).ToArray();
+            Assert.All(entries, entry =>
+            {
+                Assert.NotNull(entry.CommitWebUri);
+                var expectedUri = new Uri($"https://example.com/{entry.Commit}");
+                Assert.Equal(expectedUri, entry.CommitWebUri);
+
+                m_CommitsClientMock.Verify(x => x.GetAsync(MatchProjectId("user/repo"), entry.Commit.Id), Times.Once);
+            });
+
+            m_CommitsClientMock.Verify(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<string>()), Times.Exactly(entries.Length));
+        }
+
+        [Theory]
+        [InlineData("gitlab.com")]
+        [InlineData("example.com")]
+        public async Task Run_creates_client_through_client_factory(string hostName)
+        {
+            // ARRANGE          
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(new[] { new GitRemote("origin", $"http://{hostName}/owner/repo.git") });
+
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+
+            // ACT 
+            await sut.RunAsync(new ApplicationChangeLog());
+
+            // ASSERT
+            m_ClientFactoryMock.Verify(x => x.CreateClient(It.IsAny<string>()), Times.Once);
+            m_ClientFactoryMock.Verify(x => x.CreateClient(hostName), Times.Once);
+        }
+
+
+        //TODO: Run does not add a commit link if commit cannot be found
+    }
+}

--- a/src/ChangeLog.Test/Integrations/GitLab/GitLabLinkTaskTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitLab/GitLabLinkTaskTest.cs
@@ -1,10 +1,17 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
 using System.Threading.Tasks;
 using GitLabApiClient;
 using GitLabApiClient.Internal.Paths;
 using GitLabApiClient.Models.Commits.Responses;
+using GitLabApiClient.Models.Issues.Responses;
+using GitLabApiClient.Models.MergeRequests.Requests;
+using GitLabApiClient.Models.MergeRequests.Responses;
+using GitLabApiClient.Models.Milestones.Responses;
+using Grynwald.ChangeLog.ConventionalCommits;
 using Grynwald.ChangeLog.Git;
 using Grynwald.ChangeLog.Integrations.GitLab;
 using Grynwald.ChangeLog.Model;
@@ -17,19 +24,30 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitLab
 {
     public class GitLabLinkTaskTest : TestBase
     {
-
         private readonly ILogger<GitLabLinkTask> m_Logger = NullLogger<GitLabLinkTask>.Instance;
         private readonly Mock<IGitLabClientFactory> m_ClientFactoryMock;
         private readonly Mock<IGitLabClient> m_ClientMock;
         private readonly Mock<ICommitsClient> m_CommitsClientMock;
+        private readonly Mock<IIssuesClient> m_IssuesClientMock;
+        private readonly Mock<IMergeRequestsClient> m_MergeRequestsClientMock;
+        private readonly Mock<IProjectsClient> m_ProjectsClientMock;
         private readonly Mock<IGitRepository> m_RepositoryMock;
 
         public GitLabLinkTaskTest()
         {
             m_CommitsClientMock = new Mock<ICommitsClient>(MockBehavior.Strict);
 
+            m_IssuesClientMock = new Mock<IIssuesClient>(MockBehavior.Strict);
+
+            m_MergeRequestsClientMock = new Mock<IMergeRequestsClient>(MockBehavior.Strict);
+
+            m_ProjectsClientMock = new Mock<IProjectsClient>(MockBehavior.Strict);
+
             m_ClientMock = new Mock<IGitLabClient>(MockBehavior.Strict);
             m_ClientMock.Setup(x => x.Commits).Returns(m_CommitsClientMock.Object);
+            m_ClientMock.Setup(x => x.Issues).Returns(m_IssuesClientMock.Object);
+            m_ClientMock.Setup(x => x.MergeRequests).Returns(m_MergeRequestsClientMock.Object);
+            m_ClientMock.Setup(x => x.Projects).Returns(m_ProjectsClientMock.Object);
 
             m_ClientFactoryMock = new Mock<IGitLabClientFactory>(MockBehavior.Strict);
             m_ClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(m_ClientMock.Object);
@@ -141,6 +159,347 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitLab
             m_ClientFactoryMock.Verify(x => x.CreateClient(hostName), Times.Once);
         }
 
+        [Theory]
+        // reference within the same repository
+        [InlineData("#23", 23, "owner/repo")]
+        // reference to another project in the same namespace
+        [InlineData("anotherRepo#42", 42, "owner/anotherRepo")]
+        // reference to another project (including project namespace)
+        [InlineData("anotherOwner/anotherRepo#42", 42, "anotherOwner/anotherRepo")]
+        [InlineData("another-Owner/another-Repo#42", 42, "another-Owner/another-Repo")]
+        [InlineData("another.Owner/another.Repo#42", 42, "another.Owner/another.Repo")]
+        [InlineData("another_Owner/another_Repo#42", 42, "another_Owner/another_Repo")]
+        public async Task Run_adds_issue_links_to_footers(string footerText, int id, string projectPath)
+        {
+            // ARRANGE            
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(new[] { new GitRemote("origin", "http://gitlab.com/owner/repo.git") });
+
+            m_CommitsClientMock
+                .Setup(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<string>()))
+                .Returns(
+                    (ProjectId projectId, string sha) => Task.FromResult(new Commit() { WebUrl = $"https://example.com/{sha}" })
+                );
+            m_IssuesClientMock
+                .Setup(x => x.GetAsync(MatchProjectId(projectPath), id))
+                .Returns(
+                    Task.FromResult(new Issue() { WebUrl = $"https://example.com/{projectPath}/issues/{id}" })
+                );
+
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+
+            var changeLog = new ApplicationChangeLog()
+            {
+                GetSingleVersionChangeLog(
+                    "1.2.3",
+                    null,
+                    GetChangeLogEntry(summary: "Entry1", commit: "01", footers: new []
+                    {
+                        new ChangeLogEntryFooter(new CommitMessageFooterName("Issue"), footerText)
+                    })
+                )
+            };
+
+            // ACT 
+            await sut.RunAsync(changeLog);
+
+            // ASSERT
+            var entries = changeLog.ChangeLogs.SelectMany(x => x.AllEntries).ToArray();
+            Assert.All(entries, entry =>
+            {
+                Assert.All(entry.Footers.Where(x => x.Name == new CommitMessageFooterName("Issue")), footer =>
+                {
+                    Assert.NotNull(footer.WebUri);
+                    var expectedUri = new Uri($"https://example.com/{projectPath}/issues/{id}");
+                    Assert.Equal(expectedUri, footer.WebUri);
+                });
+
+            });
+
+            m_IssuesClientMock.Verify(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<int>()), Times.Once);
+            m_IssuesClientMock.Verify(x => x.GetAsync(MatchProjectId(projectPath), id), Times.Once);
+        }
+
+
+        [Theory]
+        // reference within the same repository
+        [InlineData("#23", 23, "owner/repo")]
+        // reference to another project in the same namespace
+        [InlineData("anotherRepo#42", 42, "owner/anotherRepo")]
+        // reference to another project (including project namespace)
+        [InlineData("anotherOwner/anotherRepo#42", 42, "anotherOwner/anotherRepo")]
+        public async Task Run_does_not_add_link_if_issue_cannot_be_found(string footerText, int id, string projectPath)
+        {
+            // ARRANGE            
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(new[] { new GitRemote("origin", "http://gitlab.com/owner/repo.git") });
+
+            m_CommitsClientMock
+                .Setup(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<string>()))
+                .Returns(
+                    (ProjectId projectId, string sha) => Task.FromResult(new Commit() { WebUrl = $"https://example.com/{sha}" })
+                );
+            m_IssuesClientMock
+                .Setup(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<int>()))
+                .Throws(new GitLabException(HttpStatusCode.NotFound));
+                
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+
+            var changeLog = new ApplicationChangeLog()
+            {
+                GetSingleVersionChangeLog(
+                    "1.2.3",
+                    null,
+                    GetChangeLogEntry(summary: "Entry1", commit: "01", footers: new []
+                    {
+                        new ChangeLogEntryFooter(new CommitMessageFooterName("Issue"), footerText)
+                    })
+                )
+            };
+
+            // ACT 
+            await sut.RunAsync(changeLog);
+
+            // ASSERT
+            var entries = changeLog.ChangeLogs.SelectMany(x => x.AllEntries).ToArray();
+            Assert.All(entries, entry =>
+            {
+                Assert.All(entry.Footers.Where(x => x.Name == new CommitMessageFooterName("Issue")), footer =>
+                {
+                    Assert.Null(footer.WebUri);                    
+                });
+
+            });
+
+            m_IssuesClientMock.Verify(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<int>()), Times.Once);
+            m_IssuesClientMock.Verify(x => x.GetAsync(MatchProjectId(projectPath), id), Times.Once);
+        }
+
+
+        [Theory]
+        // reference within the same repository
+        [InlineData("!23", 23, "owner/repo")]
+        // reference to another project in the same namespace
+        [InlineData("anotherRepo!42", 42, "owner/anotherRepo")]
+        // reference to another project (including project namespace)
+        [InlineData("anotherOwner/anotherRepo!42", 42, "anotherOwner/anotherRepo")]
+        [InlineData("another-Owner/another-Repo!42", 42, "another-Owner/another-Repo")]
+        [InlineData("another.Owner/another.Repo!42", 42, "another.Owner/another.Repo")]
+        [InlineData("another_Owner/another_Repo!42", 42, "another_Owner/another_Repo")]
+        public async Task Run_adds_merge_request_links_to_footers(string footerText, int id, string projectPath)
+        {
+            // ARRANGE            
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(new[] { new GitRemote("origin", "http://gitlab.com/owner/repo.git") });
+
+            m_CommitsClientMock
+                .Setup(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<string>()))
+                .Returns(
+                    (ProjectId projectId, string sha) => Task.FromResult(new Commit() { WebUrl = $"https://example.com/{sha}" })
+                );
+            m_MergeRequestsClientMock
+                .Setup(x => x.GetAsync(MatchProjectId(projectPath), It.IsAny<Action<ProjectMergeRequestsQueryOptions>>()))
+                .Returns(
+                    Task.FromResult<IList<MergeRequest>>(new List<MergeRequest>() { new MergeRequest() { WebUrl = $"https://example.com/{projectPath}/merge_requests/{id}" } })
+                );
+
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+
+            var changeLog = new ApplicationChangeLog()
+            {
+                GetSingleVersionChangeLog(
+                    "1.2.3",
+                    null,
+                    GetChangeLogEntry(summary: "Entry1", commit: "01", footers: new []
+                    {
+                        new ChangeLogEntryFooter(new CommitMessageFooterName("Merge-Request"), footerText)
+                    })
+                )
+            };
+
+            // ACT 
+            await sut.RunAsync(changeLog);
+
+            // ASSERT
+            var entries = changeLog.ChangeLogs.SelectMany(x => x.AllEntries).ToArray();
+            Assert.All(entries, entry =>
+            {
+                Assert.All(entry.Footers.Where(x => x.Name == new CommitMessageFooterName("Issue")), footer =>
+                {
+                    Assert.NotNull(footer.WebUri);
+                    var expectedUri = new Uri($"https://example.com/{projectPath}/issues/{id}");
+                    Assert.Equal(expectedUri, footer.WebUri);
+                });
+
+            });
+
+            m_MergeRequestsClientMock.Verify(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<Action<ProjectMergeRequestsQueryOptions>>()), Times.Once);
+            m_MergeRequestsClientMock.Verify(x => x.GetAsync(MatchProjectId(projectPath), It.IsAny<Action<ProjectMergeRequestsQueryOptions>>()), Times.Once);
+        }
+
+        [Theory]
+        // reference within the same repository
+        [InlineData("!23", "owner/repo")]
+        // reference to another project in the same namespace
+        [InlineData("anotherRepo!42", "owner/anotherRepo")]
+        // reference to another project (including project namespace)
+        [InlineData("anotherOwner/anotherRepo!42", "anotherOwner/anotherRepo")]
+        public async Task Run_does_not_add_link_if_merge_request_cannot_be_found(string footerText, string projectPath)
+        {
+            // ARRANGE            
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(new[] { new GitRemote("origin", "http://gitlab.com/owner/repo.git") });
+
+            m_CommitsClientMock
+                .Setup(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<string>()))
+                .Returns(
+                    (ProjectId projectId, string sha) => Task.FromResult(new Commit() { WebUrl = $"https://example.com/{sha}" })
+                );
+            m_MergeRequestsClientMock
+                .Setup(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<Action<ProjectMergeRequestsQueryOptions>>()))
+                .Throws(new GitLabException(HttpStatusCode.NotFound));
+
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+
+            var changeLog = new ApplicationChangeLog()
+            {
+                GetSingleVersionChangeLog(
+                    "1.2.3",
+                    null,
+                    GetChangeLogEntry(summary: "Entry1", commit: "01", footers: new []
+                    {
+                        new ChangeLogEntryFooter(new CommitMessageFooterName("Merge-Request"), footerText)
+                    })
+                )
+            };
+
+            // ACT 
+            await sut.RunAsync(changeLog);
+
+            // ASSERT
+            var entries = changeLog.ChangeLogs.SelectMany(x => x.AllEntries).ToArray();
+            Assert.All(entries, entry =>
+            {
+                Assert.All(entry.Footers.Where(x => x.Name == new CommitMessageFooterName("Issue")), footer =>
+                {
+                    Assert.Null(footer.WebUri);
+                });
+
+            });
+
+            m_MergeRequestsClientMock.Verify(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<Action<ProjectMergeRequestsQueryOptions>>()), Times.Once);
+            m_MergeRequestsClientMock.Verify(x => x.GetAsync(MatchProjectId(projectPath), It.IsAny<Action<ProjectMergeRequestsQueryOptions>>()), Times.Once);
+        }
+
+
+        [Theory]
+        // reference within the same repository
+        [InlineData("%23", 23, "owner/repo")]
+        // reference to another project in the same namespace
+        [InlineData("anotherRepo%42", 42, "owner/anotherRepo")]
+        // reference to another project (including project namespace)
+        [InlineData("anotherOwner/anotherRepo%42", 42, "anotherOwner/anotherRepo")]
+        [InlineData("another-Owner/another-Repo%42", 42, "another-Owner/another-Repo")]
+        [InlineData("another.Owner/another.Repo%42", 42, "another.Owner/another.Repo")]
+        [InlineData("another_Owner/another_Repo%42", 42, "another_Owner/another_Repo")]
+        public async Task Run_adds_milestone_links_to_footers(string footerText, int id, string projectPath)
+        {
+            // ARRANGE            
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(new[] { new GitRemote("origin", "http://gitlab.com/owner/repo.git") });
+
+            m_CommitsClientMock
+                .Setup(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<string>()))
+                .Returns(
+                    (ProjectId projectId, string sha) => Task.FromResult(new Commit() { WebUrl = $"https://example.com/{sha}" })
+                );
+            m_ProjectsClientMock
+                .Setup(x => x.GetMilestoneAsync(MatchProjectId(projectPath), id))
+                .Returns(
+                    Task.FromResult(new Milestone() { WebUrl = $"https://example.com/{projectPath}/milestones/{id}" } )
+                );
+
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+
+            var changeLog = new ApplicationChangeLog()
+            {
+                GetSingleVersionChangeLog(
+                    "1.2.3",
+                    null,
+                    GetChangeLogEntry(summary: "Entry1", commit: "01", footers: new []
+                    {
+                        new ChangeLogEntryFooter(new CommitMessageFooterName("Merge-Request"), footerText)
+                    })
+                )
+            };
+
+            // ACT 
+            await sut.RunAsync(changeLog);
+
+            // ASSERT
+            var entries = changeLog.ChangeLogs.SelectMany(x => x.AllEntries).ToArray();
+            Assert.All(entries, entry =>
+            {
+                Assert.All(entry.Footers.Where(x => x.Name == new CommitMessageFooterName("Milestone")), footer =>
+                {
+                    Assert.NotNull(footer.WebUri);
+                    var expectedUri = new Uri($"https://example.com/{projectPath}/milestones/{id}");
+                    Assert.Equal(expectedUri, footer.WebUri);
+                });
+
+            });
+
+            m_ProjectsClientMock.Verify(x => x.GetMilestoneAsync(It.IsAny<ProjectId>(), It.IsAny<int>()), Times.Once);
+            m_ProjectsClientMock.Verify(x => x.GetMilestoneAsync(MatchProjectId(projectPath), id), Times.Once);
+        }
+
+        [Theory]
+        // reference within the same repository
+        [InlineData("%23", 23, "owner/repo")]
+        // reference to another project in the same namespace
+        [InlineData("anotherRepo%42", 42, "owner/anotherRepo")]
+        // reference to another project (including project namespace)
+        [InlineData("anotherOwner/anotherRepo%42", 42, "anotherOwner/anotherRepo")]
+        public async Task Run_does_not_add_link_if_milestone_cannot_be_found(string footerText, int id, string projectPath)
+        {
+            // ARRANGE            
+            m_RepositoryMock.Setup(x => x.Remotes).Returns(new[] { new GitRemote("origin", "http://gitlab.com/owner/repo.git") });
+
+            m_CommitsClientMock
+                .Setup(x => x.GetAsync(It.IsAny<ProjectId>(), It.IsAny<string>()))
+                .Returns(
+                    (ProjectId projectId, string sha) => Task.FromResult(new Commit() { WebUrl = $"https://example.com/{sha}" })
+                );
+            m_ProjectsClientMock
+                .Setup(x => x.GetMilestoneAsync(It.IsAny<ProjectId>(), It.IsAny<int>()))
+                .Throws(new GitLabException(HttpStatusCode.NotFound));
+
+            var sut = new GitLabLinkTask(m_Logger, m_RepositoryMock.Object, m_ClientFactoryMock.Object);
+
+            var changeLog = new ApplicationChangeLog()
+            {
+                GetSingleVersionChangeLog(
+                    "1.2.3",
+                    null,
+                    GetChangeLogEntry(summary: "Entry1", commit: "01", footers: new []
+                    {
+                        new ChangeLogEntryFooter(new CommitMessageFooterName("Merge-Request"), footerText)
+                    })
+                )
+            };
+
+            // ACT 
+            await sut.RunAsync(changeLog);
+
+            // ASSERT
+            var entries = changeLog.ChangeLogs.SelectMany(x => x.AllEntries).ToArray();
+            Assert.All(entries, entry =>
+            {
+                Assert.All(entry.Footers.Where(x => x.Name == new CommitMessageFooterName("Milestone")), footer =>
+                {
+                    Assert.Null(footer.WebUri);
+                });
+
+            });
+
+            m_ProjectsClientMock.Verify(x => x.GetMilestoneAsync(It.IsAny<ProjectId>(), It.IsAny<int>()), Times.Once);
+            m_ProjectsClientMock.Verify(x => x.GetMilestoneAsync(MatchProjectId(projectPath), id), Times.Once);
+        }
 
         //TODO: Run does not add a commit link if commit cannot be found
     }

--- a/src/ChangeLog.Test/Integrations/GitLab/GitLabProjectInfoTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitLab/GitLabProjectInfoTest.cs
@@ -1,0 +1,26 @@
+﻿using Grynwald.ChangeLog.Integrations.GitLab;
+using Xunit;
+
+namespace Grynwald.ChangeLog.Test.Integrations.GitLab
+{
+    public class GitLabProjectInfoTest
+    {
+        [Theory]
+        [InlineData("example.com", "example.com", "user/repo", "user/repo")]
+        // Comparisons must be case-insensitive
+        [InlineData("EXAMPLE.COM", "example.com", "user/repo", "user/repo")]
+        [InlineData("example.com", "example.com", "USER/repo", "user/repo")]
+        [InlineData("example.com", "example.com", "user/REPO", "user/repo")]
+        [InlineData("example.com", "example.com", "user/repo", "USER/repo")]
+        [InlineData("example.com", "example.com", "user/repo", "user/REPO")]
+        public void Equals_returns_true_is_all_properties_are_equal(string host1, string host2, string projectPath1, string projectPath2)
+        {
+            var instance1 = new GitLabProjectInfo(host1, projectPath1);
+            var instance2 = new GitLabProjectInfo(host2, projectPath2);
+
+            Assert.Equal(instance1, instance2);
+            Assert.Equal(instance1.GetHashCode(), instance2.GetHashCode());
+        }
+
+    }
+}

--- a/src/ChangeLog.Test/Integrations/GitLab/GitLabProjectInfoTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitLab/GitLabProjectInfoTest.cs
@@ -6,17 +6,20 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitLab
     public class GitLabProjectInfoTest
     {
         [Theory]
-        [InlineData("example.com", "example.com", "user/repo", "user/repo")]
+        [InlineData("example.com", "example.com", "user", "user", "repo", "repo")]
+        [InlineData("example.com", "example.com", "group/subgroup", "group/subgroup", "repo", "repo")]
         // Comparisons must be case-insensitive
-        [InlineData("EXAMPLE.COM", "example.com", "user/repo", "user/repo")]
-        [InlineData("example.com", "example.com", "USER/repo", "user/repo")]
-        [InlineData("example.com", "example.com", "user/REPO", "user/repo")]
-        [InlineData("example.com", "example.com", "user/repo", "USER/repo")]
-        [InlineData("example.com", "example.com", "user/repo", "user/REPO")]
-        public void Equals_returns_true_is_all_properties_are_equal(string host1, string host2, string projectPath1, string projectPath2)
+        [InlineData("EXAMPLE.COM", "example.com", "user", "user", "repo", "repo")]
+        [InlineData("example.com", "example.com", "USER", "user", "repo", "repo")]
+        [InlineData("example.com", "example.com", "user", "user", "REPO", "repo")]
+        [InlineData("example.com", "example.com", "user", "USER", "repo", "repo")]
+        [InlineData("example.com", "example.com", "user", "user", "repo", "REPO")]
+        [InlineData("example.com", "example.com", "group/subgroup", "group/SUBGROUP", "repo", "repo")]
+        [InlineData("example.com", "example.com", "GROUP/subgroup", "group/subgroup", "repo", "repo")]        
+        public void Equals_returns_true_is_all_properties_are_equal(string host1, string host2, string namespace1, string namespace2, string project1, string project2)
         {
-            var instance1 = new GitLabProjectInfo(host1, projectPath1);
-            var instance2 = new GitLabProjectInfo(host2, projectPath2);
+            var instance1 = new GitLabProjectInfo(host1, namespace1, project1);
+            var instance2 = new GitLabProjectInfo(host2, namespace2, project2);
 
             Assert.Equal(instance1, instance2);
             Assert.Equal(instance1.GetHashCode(), instance2.GetHashCode());

--- a/src/ChangeLog.Test/Integrations/GitLab/GitLabUrlParserTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitLab/GitLabUrlParserTest.cs
@@ -17,23 +17,24 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitLab
         [InlineData("not-a-url")]
         [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
         [InlineData("http://gitlab.com")]               // missing project path
+        [InlineData("http://gitlab.com/user")]          // missing project name
         public void ParseRemoteUrl_throws_ArgumentException_for_invalid_input(string url)
         {
             Assert.ThrowsAny<ArgumentException>(() => GitLabUrlParser.ParseRemoteUrl(url));
         }
 
         [Theory]
-        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user/reponame")]
-        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup/reponame")]
-        [InlineData("https://example.com/user/repoName.git", "example.com", "user/reponame")]
-        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user/repoName")]
-        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup/repoName")]
-        [InlineData("git@example.com:user/repoName.git", "example.com", "user/repoName")]
-        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup/repoName")]
-        public void ParseRemoteUrl_returns_the_expected_GitLabProjectInfo(string remoteUrl, string host, string projectPath)
+        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
+        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
+        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
+        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
+        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
+        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
+        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
+        public void ParseRemoteUrl_returns_the_expected_GitLabProjectInfo(string remoteUrl, string host, string @namespace, string proejctName)
         {
             // ARRANGE
-            var expected = new GitLabProjectInfo(host, projectPath);
+            var expected = new GitLabProjectInfo(host, @namespace, proejctName);
 
             // ACT
             var actual = GitLabUrlParser.ParseRemoteUrl(remoteUrl);
@@ -50,23 +51,24 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitLab
         [InlineData("not-a-url")]
         [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
         [InlineData("http://gitlab.com")]               // missing project path
+        [InlineData("http://gitlab.com/user")]          // missing project name
         public void TryParseRemoteUrl_returns_false_for_invalid_input(string url)
         {
             Assert.False(GitLabUrlParser.TryParseRemoteUrl(url, out var uri));
         }
 
         [Theory]
-        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user/reponame")]
-        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup/reponame")]
-        [InlineData("https://example.com/user/repoName.git", "example.com", "user/reponame")]
-        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user/repoName")]
-        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup/repoName")]
-        [InlineData("git@example.com:user/repoName.git", "example.com", "user/repoName")]
-        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup/repoName")]
-        public void TryParseRemoteUrl_returns_the_expected_GitHubProjectInfo(string url, string host, string projectPath)
+        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
+        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
+        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
+        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
+        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
+        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
+        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
+        public void TryParseRemoteUrl_returns_the_expected_GitHubProjectInfo(string url, string host, string @namespace, string projectName)
         {
             // ARRANGE
-            var expected = new GitLabProjectInfo(host, projectPath);
+            var expected = new GitLabProjectInfo(host, @namespace, projectName);
             // ACT 
             var success = GitLabUrlParser.TryParseRemoteUrl(url, out var projectInfo);
 

--- a/src/ChangeLog.Test/Integrations/GitLab/GitLabUrlParserTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitLab/GitLabUrlParserTest.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Grynwald.ChangeLog.Integrations.GitLab;
+using Xunit;
+
+namespace Grynwald.ChangeLog.Test.Integrations.GitLab
+{
+    /// <summary>
+    /// Unit tests for <see cref="GitLabUrlParser"/>
+    /// </summary>
+    public class GitLabUrlParserTest
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("\t")]
+        [InlineData("  ")]
+        [InlineData("not-a-url")]
+        [InlineData("ftp://github.com/owner/repo.git")] // unsupported scheme
+        public void ParseRemoteUrl_throws_ArgumentException_for_invalid_input(string url)
+        {
+            Assert.ThrowsAny<ArgumentException>(() => GitLabUrlParser.ParseRemoteUrl(url));
+        }
+
+        [Theory]
+        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user/reponame")]
+        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup/reponame")]
+        [InlineData("https://example.com/user/repoName.git", "example.com", "user/reponame")]
+        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user/repoName")]
+        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup/repoName")]
+        [InlineData("git@example.com:user/repoName.git", "example.com", "user/repoName")]
+        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup/repoName")]
+        public void ParseRemoteUrl_returns_the_expected_GitLabProjectInfo(string remoteUrl, string host, string projectPath)
+        {
+            // ARRANGE
+            var expected = new GitLabProjectInfo(host, projectPath);
+
+            // ACT
+            var actual = GitLabUrlParser.ParseRemoteUrl(remoteUrl);
+
+            // ASSERT
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("\t")]
+        [InlineData("  ")]
+        [InlineData("not-a-url")]        
+        public void TryParseRemoteUrl_returns_false_for_invalid_input(string url)
+        {
+            Assert.False(GitLabUrlParser.TryParseRemoteUrl(url, out var uri));
+        }
+
+        [Theory]
+        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user/reponame")]
+        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup/reponame")]
+        [InlineData("https://example.com/user/repoName.git", "example.com", "user/reponame")]
+        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user/repoName")]
+        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup/repoName")]
+        [InlineData("git@example.com:user/repoName.git", "example.com", "user/repoName")]
+        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup/repoName")]
+        public void TryParseRemoteUrl_returns_the_expected_GitHubProjectInfo(string url, string host, string projectPath)
+        {
+            // ARRANGE
+            var expected = new GitLabProjectInfo(host, projectPath);
+            // ACT 
+            var success = GitLabUrlParser.TryParseRemoteUrl(url, out var projectInfo);
+
+            // ASSERT
+            Assert.True(success);
+            Assert.Equal(expected, projectInfo);
+        }
+    }
+}

--- a/src/ChangeLog.Test/Integrations/GitLab/GitLabUrlParserTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitLab/GitLabUrlParserTest.cs
@@ -15,7 +15,8 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitLab
         [InlineData("\t")]
         [InlineData("  ")]
         [InlineData("not-a-url")]
-        [InlineData("ftp://github.com/owner/repo.git")] // unsupported scheme
+        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
+        [InlineData("http://gitlab.com")]               // missing project path
         public void ParseRemoteUrl_throws_ArgumentException_for_invalid_input(string url)
         {
             Assert.ThrowsAny<ArgumentException>(() => GitLabUrlParser.ParseRemoteUrl(url));
@@ -46,7 +47,9 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitLab
         [InlineData("")]
         [InlineData("\t")]
         [InlineData("  ")]
-        [InlineData("not-a-url")]        
+        [InlineData("not-a-url")]
+        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
+        [InlineData("http://gitlab.com")]               // missing project path
         public void TryParseRemoteUrl_returns_false_for_invalid_input(string url)
         {
             Assert.False(GitLabUrlParser.TryParseRemoteUrl(url, out var uri));

--- a/src/ChangeLog.sln
+++ b/src/ChangeLog.sln
@@ -12,43 +12,34 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitLabApiClient", "..\deps\GitLabApiClient\src\GitLabApiClient\GitLabApiClient.csproj", "{F682B2B4-DC0E-4B52-A75D-2339767B844F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "deps", "deps", "{72E52B85-6214-400B-9DD0-AC1890341EF2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Debug|x64.Build.0 = Debug|Any CPU
-		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Debug|x86.Build.0 = Debug|Any CPU
 		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Release|x64.ActiveCfg = Release|Any CPU
-		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Release|x64.Build.0 = Release|Any CPU
-		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Release|x86.ActiveCfg = Release|Any CPU
-		{794CE9DC-3F83-417F-8911-A6645B6C762F}.Release|x86.Build.0 = Release|Any CPU
 		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Debug|x64.Build.0 = Debug|Any CPU
-		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Debug|x86.Build.0 = Debug|Any CPU
 		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Release|Any CPU.Build.0 = Release|Any CPU
-		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Release|x64.ActiveCfg = Release|Any CPU
-		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Release|x64.Build.0 = Release|Any CPU
-		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Release|x86.ActiveCfg = Release|Any CPU
-		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69}.Release|x86.Build.0 = Release|Any CPU
+		{F682B2B4-DC0E-4B52-A75D-2339767B844F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F682B2B4-DC0E-4B52-A75D-2339767B844F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F682B2B4-DC0E-4B52-A75D-2339767B844F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F682B2B4-DC0E-4B52-A75D-2339767B844F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F682B2B4-DC0E-4B52-A75D-2339767B844F} = {72E52B85-6214-400B-9DD0-AC1890341EF2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {87929660-5CD6-4938-983E-81B0B0DE86D6}

--- a/src/ChangeLog/CommandLineParameters.cs
+++ b/src/ChangeLog/CommandLineParameters.cs
@@ -17,7 +17,7 @@ namespace Grynwald.ChangeLog
         [ConfigurationValue("changelog:outputPath")]
         public string? OutputPath
         {
-            // is value is set, return an absolute path
+            // if value is set, return an absolute path
             // otherwise, if a relative path is passed through the configuration system
             // it would be interpreted as being relative to the repository path.
             // However, when specifying a relative path on the command line, it makes much more sense
@@ -29,6 +29,10 @@ namespace Grynwald.ChangeLog
         [Option("gitHubAccessToken", Required = false)]
         [ConfigurationValue("changelog:integrations:github:accesstoken")]
         public string? GitHubAccessToken { get; set; }
+
+        [Option("gitLabAccessToken", Required = false)]
+        [ConfigurationValue("changelog:integrations:gitlab:accesstoken")]
+        public string? GitLabAccessToken { get; set; }
 
         [Option("verbose", Required = false, Default = false)]
         public bool Verbose { get; set; }

--- a/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
+++ b/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
@@ -43,11 +43,18 @@ namespace Grynwald.ChangeLog.Configuration
             public string? AccessToken { get; set; } = null;
         }
 
+        public class GitLabIntegrationConfiguration
+        {
+            public string? AccessToken { get; set; } = null;
+        }
+
         public class IntegrationsConfiguration
         {
             public IntegrationProvider Provider { get; set; }
 
             public GitHubIntegrationConfiguration GitHub { get; set; } = new GitHubIntegrationConfiguration();
+
+            public GitLabIntegrationConfiguration GitLab { get; set; } = new GitLabIntegrationConfiguration();
         }
 
 

--- a/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
+++ b/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
@@ -35,7 +35,8 @@ namespace Grynwald.ChangeLog.Configuration
         public enum IntegrationProvider
         {
             None = 0,
-            GitHub = 1
+            GitHub = 1,
+            GitLab = 2,
         }
 
         public class GitHubIntegrationConfiguration

--- a/src/ChangeLog/Configuration/defaultSettings.json
+++ b/src/ChangeLog/Configuration/defaultSettings.json
@@ -54,7 +54,7 @@
 
       // Set the integration provider to use
       // Default: none
-      // Supported values: "None", "GitHub"
+      // Supported values: "None", "GitHub", "GitLab"
       "provider": "none",
 
       // Settings specific to the GitHub integration

--- a/src/ChangeLog/Configuration/defaultSettings.json
+++ b/src/ChangeLog/Configuration/defaultSettings.json
@@ -63,6 +63,14 @@
         // The GitHub access token can be set in the configuration file BUT SHOULDN'T.
         // Use the "githubAccessToken" command line parameter instead
         "accessToken": null
+      },
+
+      // Settings specific to the GitLab integration
+      "gitlab": {
+
+        // The GitLab access token can be set in the configuration file BUT SHOULDN'T.
+        // Use the "gitlabAccessToken" command line parameter instead
+        "accessToken": null
       }
     },
 

--- a/src/ChangeLog/Grynwald.ChangeLog.csproj
+++ b/src/ChangeLog/Grynwald.ChangeLog.csproj
@@ -31,4 +31,8 @@
     <PackageReference Include="Autofac" Version="5.1.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\deps\GitLabApiClient\src\GitLabApiClient\GitLabApiClient.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/ChangeLog/Integrations/GitHub/GitHubLinkTask.cs
+++ b/src/ChangeLog/Integrations/GitHub/GitHubLinkTask.cs
@@ -33,6 +33,8 @@ namespace Grynwald.ChangeLog.Integrations.GitHub
             m_Repository = repository ?? throw new ArgumentNullException(nameof(repository));
             m_GitHubClientFactory = gitHubClientFactory ?? throw new ArgumentNullException(nameof(gitHubClientFactory));
 
+            // TODO: Allow configuration of remote name
+            // TODO: Allow bypassing parsing by setting project info in the config file
             var remote = m_Repository.Remotes.FirstOrDefault(r => StringComparer.OrdinalIgnoreCase.Equals(r.Name, "origin"));
             if (remote != null && GitHubUrlParser.TryParseRemoteUrl(remote.Url, out var projectInfo))
             {

--- a/src/ChangeLog/Integrations/GitHub/GitHubUrlParser.cs
+++ b/src/ChangeLog/Integrations/GitHub/GitHubUrlParser.cs
@@ -5,12 +5,9 @@ namespace Grynwald.ChangeLog.Integrations.GitHub
 {
     internal static class GitHubUrlParser
     {
-        private static readonly char[] s_ScpUrlSplitChars = new[] { ':' };
-
-
         public static GitHubProjectInfo ParseRemoteUrl(string url)
         {
-            if(TryParseRemoteUrl(url, out var projectInfo, out var errorMessage))
+            if (TryParseRemoteUrl(url, out var projectInfo, out var errorMessage))
             {
                 return projectInfo;
             }
@@ -34,8 +31,7 @@ namespace Grynwald.ChangeLog.Integrations.GitHub
                 return false;
             }
 
-
-            if (!TryParseUrl(url, out var uri))
+            if (!GitUrl.TryGetUri(url, out var uri))
             {
                 errorMessage = $"Value '{url}' is not a valid uri";
                 return false;
@@ -47,7 +43,7 @@ namespace Grynwald.ChangeLog.Integrations.GitHub
                 case "https":
                 case "ssh":
                     var path = uri.AbsolutePath.Trim('/');
-                    path = RemoveSuffix(path, ".git");
+                    path = path.RemoveSuffix(".git");
 
                     var ownerAndRepo = path.Split('/');
                     if (ownerAndRepo.Length != 2)
@@ -64,46 +60,5 @@ namespace Grynwald.ChangeLog.Integrations.GitHub
                     return false;
             }
         }
-
-        private static bool TryParseUrl(string url, [NotNullWhen(true)]out Uri? uri)
-        {
-            if (Uri.TryCreate(url, UriKind.Absolute, out uri))
-            {
-                return true;
-            }
-            else
-            {
-                return TryParseScpUrl(url, out uri);
-            }
-        }
-
-        private static bool TryParseScpUrl(string url, [NotNullWhen(true)]out Uri? sshUri)
-        {
-            // Parse a scp-format git url: e.g. git@github.com:ap0llo/changelog-creator.git
-
-            var fragments = url.Split(s_ScpUrlSplitChars, StringSplitOptions.RemoveEmptyEntries);
-            if (fragments.Length != 2)
-            {
-                sshUri = default;
-                return false;
-            }
-
-            var userNameAndHost = fragments[0];
-            var path = fragments[1].TrimStart('/');
-
-            return Uri.TryCreate($"ssh://{userNameAndHost}/{path}", UriKind.Absolute, out sshUri);
-        }
-
-        private static string RemoveSuffix(string value, string suffix)
-        {
-            return value.EndsWith(suffix)
-#if NETCOREAPP2_1
-                ? value.Substring(0, value.Length - suffix.Length)
-#else
-                ? value[..^suffix.Length]
-#endif
-                : value;
-        }
-
     }
 }

--- a/src/ChangeLog/Integrations/GitLab/GitLabClientFactory.cs
+++ b/src/ChangeLog/Integrations/GitLab/GitLabClientFactory.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using GitLabApiClient;
+using Grynwald.ChangeLog.Configuration;
+
+namespace Grynwald.ChangeLog.Integrations.GitLab
+{
+    internal class GitLabClientFactory : IGitLabClientFactory
+    {
+        private readonly ChangeLogConfiguration m_Configuration;
+
+        public GitLabClientFactory(ChangeLogConfiguration configuration)
+        {
+            m_Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+
+        public IGitLabClient CreateClient(string hostName)
+        {
+            var accessToken = m_Configuration.Integrations.GitLab.AccessToken ?? "";
+            var client = new GitLabClient($"https://{hostName}/", accessToken);
+            return client;
+        }
+    }
+}

--- a/src/ChangeLog/Integrations/GitLab/GitLabLinkTask.cs
+++ b/src/ChangeLog/Integrations/GitLab/GitLabLinkTask.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using GitLabApiClient;
 using Grynwald.ChangeLog.Git;
@@ -12,6 +14,17 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
 {
     internal sealed class GitLabLinkTask : IChangeLogTask
     {
+        private enum GitLabReferenceType
+        {
+            Issue,
+            MergeRequest,
+            Milestone
+        }
+
+        private const RegexOptions s_RegexOptions = RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled;
+        private static readonly Regex s_GitLabReferencePattern = new Regex("^((?<namespace>[A-Z0-9-_./]+)/)?(?<project>[A-Z0-9-_.]+)?(?<type>(#|!|%))(?<id>\\d+)$", s_RegexOptions);
+
+
         private readonly ILogger<GitLabLinkTask> m_Logger;
         private readonly IGitRepository m_Repository;
         private readonly IGitLabClientFactory m_ClientFactory;
@@ -57,6 +70,7 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
             }
         }
 
+
         private async Task ProcessEntryAsync(IGitLabClient githubClient, ChangeLogEntry entry)
         {
             m_Logger.LogDebug($"Adding links to entry {entry.Commit}");
@@ -71,6 +85,23 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
             {
                 m_Logger.LogWarning($"Failed to determine web uri for commit '{entry.Commit}'");
             }
+
+
+            foreach (var footer in entry.Footers)
+            {
+                if (TryParseReference(footer.Value, out var type, out var projectPath, out var id))
+                {
+                    var uri = await TryGetWebUriAsync(githubClient, type.Value, projectPath, id);
+                    if (uri != null)
+                    {
+                        footer.WebUri = uri;
+                    }
+                    else
+                    {
+                        m_Logger.LogWarning($"Failed to determine web uri for issue '{projectPath}#{id}'");
+                    }
+                }
+            }
         }
 
         private async Task<Uri?> TryGetWebUriAsync(IGitLabClient gitlabClient, GitId commitId)
@@ -84,6 +115,139 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
             {
                 var commit = await gitlabClient.Commits.GetAsync(m_ProjectInfo.ProjectPath, commitId.Id);
                 return new Uri(commit.WebUrl);
+            }
+            catch (Exception ex) when (ex is GitLabException gitlabException && gitlabException.HttpStatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
+
+        private bool TryParseReference(string input, [NotNullWhen(true)] out GitLabReferenceType? type, [NotNullWhen(true)] out string? projectPath, out int id)
+        {
+            if (m_ProjectInfo == null)
+                throw new InvalidOperationException();
+
+            var match = s_GitLabReferencePattern.Match(input);
+
+            if (match.Success)
+            {
+                var idString = match.Groups["id"].ToString();
+                if (Int32.TryParse(idString, out id))
+                {
+                    var projectNamespace = match.Groups["namespace"].Value;
+                    var projectName = match.Groups["project"].Value;
+                    var typeString = match.Groups["type"].Value;
+
+                    switch (typeString)
+                    {
+                        case "#":
+                            type = GitLabReferenceType.Issue;
+                            break;
+                        case "!":
+                            type = GitLabReferenceType.MergeRequest;
+                            break;
+                        case "%":
+                            type = GitLabReferenceType.Milestone;
+                            break;
+
+                        default:
+                            type = null;
+                            projectPath = null;
+                            id = -1;
+                            return false;
+                    }
+
+                    // no project name or namespace => reference within the current project
+                    if (String.IsNullOrEmpty(projectNamespace) && String.IsNullOrEmpty(projectName))
+                    {
+                        projectPath = m_ProjectInfo.ProjectPath;
+                        return true;
+                    }
+                    // project name without namespace => reference to another project within the same namespace
+                    else if (String.IsNullOrEmpty(projectNamespace) && !String.IsNullOrEmpty(projectName))
+                    {
+                        projectPath = $"{m_ProjectInfo.Namespace}/{projectName}";
+                        return true;
+                    }
+                    // namespace and project name found => full reference
+                    else if (!String.IsNullOrEmpty(projectNamespace) && !String.IsNullOrEmpty(projectName))
+                    {
+                        projectPath = $"{projectNamespace}/{projectName}";
+                        return true;
+                    }
+                }
+            }
+
+            type = null;
+            projectPath = null;
+            id = -1;
+            return false;
+        }
+
+        private Task<Uri?> TryGetWebUriAsync(IGitLabClient gitlabClient, GitLabReferenceType type, string projectPath, int id)
+        {
+            switch (type)
+            {
+                case GitLabReferenceType.Issue:
+                    return TryGetIssueWebUriAsync(gitlabClient, projectPath, id);
+
+                case GitLabReferenceType.MergeRequest:
+                    return TryGetMergeRequestWebUriAsync(gitlabClient, projectPath, id);
+
+                case GitLabReferenceType.Milestone:
+                    return TryGetMilestoneWebUriAsync(gitlabClient, projectPath, id);
+
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        private async Task<Uri?> TryGetIssueWebUriAsync(IGitLabClient gitlabClient, string projectPath, int id)
+        {
+            m_Logger.LogDebug($"Getting web uri for issue {id}");
+
+            try
+            {
+                var issue = await gitlabClient.Issues.GetAsync(projectPath, id);
+                return new Uri(issue.WebUrl);
+            }
+            catch (Exception ex) when (ex is GitLabException gitlabException && gitlabException.HttpStatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
+
+        private async Task<Uri?> TryGetMergeRequestWebUriAsync(IGitLabClient gitlabClient, string projectPath, int id)
+        {
+            m_Logger.LogDebug($"Getting web uri for Merge Request {id}");
+
+            try
+            {
+                var mergeRequests = await gitlabClient.MergeRequests.GetAsync(projectPath, query => { query.MergeRequestsIds.Add(id); });
+                if (mergeRequests.Count == 1)
+                {
+                    return new Uri(mergeRequests.Single().WebUrl); ;
+                }
+                else
+                {
+                    return null;
+                }
+
+            }
+            catch (Exception ex) when (ex is GitLabException gitlabException && gitlabException.HttpStatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
+
+        private async Task<Uri?> TryGetMilestoneWebUriAsync(IGitLabClient gitlabClient, string projectPath, int id)
+        {
+            m_Logger.LogDebug($"Getting web uri for Milestone {id}");
+
+            try
+            {
+                var milestone = await gitlabClient.Projects.GetMilestoneAsync(projectPath, id);
+                return new Uri(milestone.WebUrl); ;
             }
             catch (Exception ex) when (ex is GitLabException gitlabException && gitlabException.HttpStatusCode == HttpStatusCode.NotFound)
             {

--- a/src/ChangeLog/Integrations/GitLab/GitLabLinkTask.cs
+++ b/src/ChangeLog/Integrations/GitLab/GitLabLinkTask.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using GitLabApiClient;
+using Grynwald.ChangeLog.Git;
+using Grynwald.ChangeLog.Model;
+using Grynwald.ChangeLog.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Grynwald.ChangeLog.Integrations.GitLab
+{
+    internal sealed class GitLabLinkTask : IChangeLogTask
+    {
+        private readonly ILogger<GitLabLinkTask> m_Logger;
+        private readonly IGitRepository m_Repository;
+        private readonly IGitLabClientFactory m_ClientFactory;
+        private readonly GitLabProjectInfo? m_ProjectInfo;
+
+
+        public GitLabLinkTask(ILogger<GitLabLinkTask> logger, IGitRepository repository, IGitLabClientFactory clientFactory)
+        {
+            m_Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            m_Repository = repository ?? throw new ArgumentNullException(nameof(repository));
+            m_ClientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+
+            // TODO: Allow configuration of remote name
+            // TODO: Allow bypassing parsing by setting project info in the config file
+            var remote = m_Repository.Remotes.FirstOrDefault(r => StringComparer.OrdinalIgnoreCase.Equals(r.Name, "origin"));
+            if (remote != null && GitLabUrlParser.TryParseRemoteUrl(remote.Url, out var projectInfo))
+            {
+                m_ProjectInfo = projectInfo;
+            }
+            else
+            {
+                m_Logger.LogWarning("Failed to determine GitLab project path. Disabling GitLab integration");
+            }
+        }
+
+
+        /// <inheritdoc />
+        public async Task RunAsync(ApplicationChangeLog changeLog)
+        {
+            if (m_ProjectInfo == null)
+                return;
+
+            m_Logger.LogInformation("Adding GitHub links to changelog");
+
+            var gitlabClient = m_ClientFactory.CreateClient(m_ProjectInfo.Host);
+
+            foreach (var versionChangeLog in changeLog.ChangeLogs)
+            {
+                foreach (var entry in versionChangeLog.AllEntries)
+                {
+                    await ProcessEntryAsync(gitlabClient, entry);
+                }
+            }
+        }
+
+        private async Task ProcessEntryAsync(IGitLabClient githubClient, ChangeLogEntry entry)
+        {
+            m_Logger.LogDebug($"Adding links to entry {entry.Commit}");
+
+            var webUri = await TryGetWebUriAsync(githubClient, entry.Commit);
+
+            if (webUri != null)
+            {
+                entry.CommitWebUri = webUri;
+            }
+            else
+            {
+                m_Logger.LogWarning($"Failed to determine web uri for commit '{entry.Commit}'");
+            }
+        }
+
+        private async Task<Uri?> TryGetWebUriAsync(IGitLabClient gitlabClient, GitId commitId)
+        {
+            if (m_ProjectInfo == null)
+                throw new InvalidOperationException();
+
+            m_Logger.LogDebug($"Getting web uri for commit '{commitId}'");
+
+            try
+            {
+                var commit = await gitlabClient.Commits.GetAsync(m_ProjectInfo.ProjectPath, commitId.Id);
+                return new Uri(commit.WebUrl);
+            }
+            catch (Exception ex) when (ex is GitLabException gitlabException && gitlabException.HttpStatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/ChangeLog/Integrations/GitLab/GitLabProjectInfo.cs
+++ b/src/ChangeLog/Integrations/GitLab/GitLabProjectInfo.cs
@@ -11,9 +11,19 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
         public string Host { get; }
 
         /// <summary>
+        /// The project namespace (the user or group (incl.subgroups) the project belongs to
+        /// </summary>
+        public string Namespace { get; }
+
+        /// <summary>
+        /// The project name
+        /// </summary>
+        public string Project { get; }
+
+        /// <summary>
         /// The GitLab project path (i.e. namespace + repository name).
         /// </summary>
-        public string ProjectPath { get; }
+        public string ProjectPath => $"{Namespace}/{Project}";
 
 
         /// <summary>
@@ -22,16 +32,20 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
         /// <param name="host">The host name of the GitLab server.</param>
         /// <param name="projectPath">The GitLab project path (i.e. namespace + repository name).</param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="host"/> or <paramref name="projectPath"/> is null or whitespace</exception>
-        public GitLabProjectInfo(string host, string projectPath)
+        public GitLabProjectInfo(string host, string @namespace, string project)
         {
             if (String.IsNullOrWhiteSpace(host))
                 throw new ArgumentException("Value must not be null or whitespace", nameof(host));
 
-            if (String.IsNullOrWhiteSpace(projectPath))
-                throw new ArgumentException("Value must not be null or whitespace", nameof(projectPath));
+            if (String.IsNullOrWhiteSpace(@namespace))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(@namespace));
+
+            if (String.IsNullOrWhiteSpace(project))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(project));
 
             Host = host;
-            ProjectPath = projectPath;
+            Namespace = @namespace.Trim('/');
+            Project = project.Trim('/');
         }
 
 
@@ -44,7 +58,8 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
             unchecked
             {
                 var hash = StringComparer.OrdinalIgnoreCase.GetHashCode(Host) * 397;
-                hash ^= StringComparer.OrdinalIgnoreCase.GetHashCode(ProjectPath);
+                hash ^= StringComparer.OrdinalIgnoreCase.GetHashCode(Namespace);
+                hash ^= StringComparer.OrdinalIgnoreCase.GetHashCode(Project);
                 return hash;
             }
         }
@@ -54,7 +69,8 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
         {
             return other != null &&
                 StringComparer.OrdinalIgnoreCase.Equals(Host, other.Host) &&
-                StringComparer.OrdinalIgnoreCase.Equals(ProjectPath, other.ProjectPath);
+                StringComparer.OrdinalIgnoreCase.Equals(Namespace, other.Namespace) &&
+                StringComparer.OrdinalIgnoreCase.Equals(Project, other.Project);
         }
     }
 }

--- a/src/ChangeLog/Integrations/GitLab/GitLabProjectInfo.cs
+++ b/src/ChangeLog/Integrations/GitLab/GitLabProjectInfo.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Grynwald.ChangeLog.Integrations.GitLab
+{
+    public sealed class GitLabProjectInfo : IEquatable<GitLabProjectInfo>
+    {
+        /// <summary>
+        /// The host name of the GitLab server.
+        /// </summary>
+        public string Host { get; }
+
+        /// <summary>
+        /// The GitLab project path (i.e. namespace + repository name).
+        /// </summary>
+        public string ProjectPath { get; }
+
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="GitLabProjectInfo"/>
+        /// </summary>
+        /// <param name="host">The host name of the GitLab server.</param>
+        /// <param name="projectPath">The GitLab project path (i.e. namespace + repository name).</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="host"/> or <paramref name="projectPath"/> is null or whitespace</exception>
+        public GitLabProjectInfo(string host, string projectPath)
+        {
+            if (String.IsNullOrWhiteSpace(host))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(host));
+
+            if (String.IsNullOrWhiteSpace(projectPath))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(projectPath));
+
+            Host = host;
+            ProjectPath = projectPath;
+        }
+
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => Equals(obj as GitLabProjectInfo);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = StringComparer.OrdinalIgnoreCase.GetHashCode(Host) * 397;
+                hash ^= StringComparer.OrdinalIgnoreCase.GetHashCode(ProjectPath);
+                return hash;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Equals([AllowNull] GitLabProjectInfo other)
+        {
+            return other != null &&
+                StringComparer.OrdinalIgnoreCase.Equals(Host, other.Host) &&
+                StringComparer.OrdinalIgnoreCase.Equals(ProjectPath, other.ProjectPath);
+        }
+    }
+}

--- a/src/ChangeLog/Integrations/GitLab/GitLabUrlParser.cs
+++ b/src/ChangeLog/Integrations/GitLab/GitLabUrlParser.cs
@@ -52,7 +52,29 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
                         return false;
                     }
 
-                    projectInfo = new GitLabProjectInfo(uri.Host, projectPath);
+                    if(!projectPath.Contains('/'))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Invalid project path '{projectPath}'";
+                        return false;
+                    }
+
+                    var splitIndex = projectPath.LastIndexOf('/');
+                    var @namespace = projectPath.Substring(0, splitIndex);
+                    var projectName = projectPath.Substring(splitIndex);
+
+                    if(String.IsNullOrWhiteSpace(@namespace))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project namespace is empty";
+                        return false;
+                    }
+
+                    if (String.IsNullOrWhiteSpace(projectName))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project name is empty";
+                        return false;
+                    }
+
+                    projectInfo = new GitLabProjectInfo(uri.Host, @namespace, projectName);
                     return true;
 
                 default:

--- a/src/ChangeLog/Integrations/GitLab/GitLabUrlParser.cs
+++ b/src/ChangeLog/Integrations/GitLab/GitLabUrlParser.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Grynwald.ChangeLog.Integrations.GitLab
+{
+    public static class GitLabUrlParser
+    {
+        public static GitLabProjectInfo ParseRemoteUrl(string url)
+        {
+            if (TryParseRemoteUrl(url, out var projectInfo, out var errorMessage))
+            {
+                return projectInfo;
+            }
+            else
+            {
+                throw new ArgumentException(errorMessage, nameof(url));
+            }
+        }
+
+        public static bool TryParseRemoteUrl(string url, [NotNullWhen(true)]out GitLabProjectInfo? projectInfo) =>
+            TryParseRemoteUrl(url, out projectInfo, out var _);
+
+
+        private static bool TryParseRemoteUrl(string url, [NotNullWhen(true)]out GitLabProjectInfo? projectInfo, [NotNullWhen(false)]out string? errorMessage)
+        {
+            projectInfo = null;
+            errorMessage = null;
+
+            if (String.IsNullOrWhiteSpace(url))
+            {
+                errorMessage = "Value must not be null or empty";
+                return false;
+            }
+
+            if (!GitUrl.TryGetUri(url, out var uri))
+            {
+                errorMessage = $"Value '{url}' is not a valid uri";
+                return false;
+            }
+
+            switch (uri.Scheme.ToLower())
+            {
+                case "http":
+                case "https":
+                case "ssh":
+                    var projectPath = uri.AbsolutePath.Trim('/');
+                    projectPath = projectPath.RemoveSuffix(".git");
+                    projectInfo = new GitLabProjectInfo(uri.Host, projectPath);
+                    return true;
+
+                default:
+                    errorMessage = $"Cannot parse '{url}' as GitLab url: Unsupported scheme '{uri.Scheme}'";
+                    return false;
+            }
+        }
+    }
+}

--- a/src/ChangeLog/Integrations/GitLab/GitLabUrlParser.cs
+++ b/src/ChangeLog/Integrations/GitLab/GitLabUrlParser.cs
@@ -45,6 +45,13 @@ namespace Grynwald.ChangeLog.Integrations.GitLab
                 case "ssh":
                     var projectPath = uri.AbsolutePath.Trim('/');
                     projectPath = projectPath.RemoveSuffix(".git");
+
+                    if(String.IsNullOrWhiteSpace(projectPath))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project path is empty";
+                        return false;
+                    }
+
                     projectInfo = new GitLabProjectInfo(uri.Host, projectPath);
                     return true;
 

--- a/src/ChangeLog/Integrations/GitLab/IGitLabClientFactory.cs
+++ b/src/ChangeLog/Integrations/GitLab/IGitLabClientFactory.cs
@@ -1,0 +1,9 @@
+﻿using GitLabApiClient;
+
+namespace Grynwald.ChangeLog.Integrations.GitLab
+{
+    internal interface IGitLabClientFactory
+    {
+        IGitLabClient CreateClient(string hostName);
+    }
+}

--- a/src/ChangeLog/Integrations/GitUrl.cs
+++ b/src/ChangeLog/Integrations/GitUrl.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Grynwald.ChangeLog.Integrations
+{
+    public static class GitUrl
+    {
+        private static readonly char[] s_ScpUrlSplitChars = new[] { ':' };
+
+
+        public static bool TryGetUri(string url, [NotNullWhen(true)]out Uri? uri)
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out uri))
+            {
+                return true;
+            }
+            else
+            {
+                return TryParseScpUrl(url, out uri);
+            }
+        }
+
+
+        private static bool TryParseScpUrl(string url, [NotNullWhen(true)]out Uri? sshUri)
+        {
+            // Parse a scp-format git url: e.g. git@github.com:ap0llo/changelog-creator.git
+
+            var fragments = url.Split(s_ScpUrlSplitChars, StringSplitOptions.RemoveEmptyEntries);
+            if (fragments.Length != 2)
+            {
+                sshUri = default;
+                return false;
+            }
+
+            var userNameAndHost = fragments[0];
+            var path = fragments[1].TrimStart('/');
+
+            return Uri.TryCreate($"ssh://{userNameAndHost}/{path}", UriKind.Absolute, out sshUri);
+        }
+    }
+}

--- a/src/ChangeLog/Integrations/IntegrationsExtensions.cs
+++ b/src/ChangeLog/Integrations/IntegrationsExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Grynwald.ChangeLog.Configuration;
 using Grynwald.ChangeLog.Integrations.GitHub;
+using Grynwald.ChangeLog.Integrations.GitLab;
 
 namespace Grynwald.ChangeLog.Integrations
 {
@@ -10,6 +11,9 @@ namespace Grynwald.ChangeLog.Integrations
         {
             containerBuilder.RegisterType<GitHubClientFactory>().As<IGitHubClientFactory>();
             containerBuilder.RegisterType<GitHubLinkTask>();
+
+            containerBuilder.RegisterType<GitLabClientFactory>().As<IGitLabClientFactory>();
+            containerBuilder.RegisterType<GitLabLinkTask>();
         }
 
 
@@ -20,6 +24,10 @@ namespace Grynwald.ChangeLog.Integrations
             if (configuration.Integrations.Provider == ChangeLogConfiguration.IntegrationProvider.GitHub)
             {
                 pipelineBuilder = pipelineBuilder.AddTask<GitHubLinkTask>();
+            }
+            else if (configuration.Integrations.Provider == ChangeLogConfiguration.IntegrationProvider.GitLab)
+            {
+                pipelineBuilder = pipelineBuilder.AddTask<GitLabLinkTask>();
             }
 
             return pipelineBuilder;

--- a/src/ChangeLog/_Extensions/StringExtensions.cs
+++ b/src/ChangeLog/_Extensions/StringExtensions.cs
@@ -1,0 +1,17 @@
+﻿namespace Grynwald.ChangeLog
+{
+    public static class StringExtensions
+    {
+        public static string RemoveSuffix(this string value, string suffix)
+        {
+            return value.EndsWith(suffix)
+#if NETCOREAPP2_1
+                ? value.Substring(0, value.Length - suffix.Length)
+#else
+                ? value[..^suffix.Length]
+#endif
+                : value;
+        }
+
+    }
+}


### PR DESCRIPTION
- [x] Link to commits on GitLab
- [x] Recognize GitLab references (see [GitLab Docs](https://docs.gitlab.com/ee/user/markdown.html#special-gitlab-references))
  - [x] Issues (e.g. `#123`)
  - [x] Merge Requests (e.g. `!123`)
  - [x] Milestones (e.g. ~`%v1.2.3`~ `%123`)
  - [x] All references can include the project path, e.g. `user/project#123`
  - [x] All references can refer to another project within the same namespace, e.g. `project#123`