### PR TITLE
Improve commit message parsing

### DIFF
--- a/changelog.settings.json
+++ b/changelog.settings.json
@@ -17,6 +17,10 @@
             {
                 "name": "templates",
                 "displayName": "Templates"
+            },
+            {
+                "name": "parser",
+                "displayName" : "Commit Message Parser"
             }
         ]
 

--- a/docs/commit-message-parser.md
+++ b/docs/commit-message-parser.md
@@ -1,0 +1,91 @@
+# Commit Message Parser
+
+ChangeLog expects commit messages to follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0).
+Messages that use that format can be parsed and included in the generated change log.
+
+The parser has two *modes*:
+
+- *Strict* mode enforces commit messages to follow the specification precisely.
+- *Loose* mode is more lenient and allows minor deviations from the specification.
+
+By default, the *Loose* mode is used.
+For documentation on how to change the parser mode, see [Configuration](./configuration.md#parser-mode).
+
+## Differences between *Strict* and *Loose* Parser modes
+
+The differences between *Strict* and *Loose* modes are listed below.
+
+### Ignore trailing blank lines
+
+In loose mode, all trailing blank lines at the end of the commit message are ignored.
+The following commit message is valid in *Loose* mode but invalid in *Strict* mode:
+
+```txt
+feat: New Feature
+
+Description of the feature
+
+
+
+
+```
+
+### Ignore duplicate blank lines
+
+Blank lines separate the commit message header from the body, different paragraphs of the message body as well as the message body from the commit message footers.
+
+In *Loose* mode, multiple consecutive blank lines are treated the same as a single blank line.
+
+The following commit message is valid in *Loose* mode but invalid in *Strict* mode:
+
+```txt
+feat: New Feature
+
+
+
+Description of the feature
+
+
+Second paragraph of the message body
+
+
+Reviewed-By: someone@example.com
+Closes #123
+```
+
+### Allow blank lines between footers
+
+Commit messages may contain one or more commit message footers.
+In *Loose* mode, one or more blank lines may appear between the individual footer while it is invalid in *Strict* mode.
+
+The following commit message is valid in *Loose* mode but invalid in *Strict* mode:
+
+```txt
+feat: New Feature
+
+Description of the feature.
+Some more description.
+
+Reviewed-By: someone@example.com
+
+Closes #123
+```
+
+### Treat whitespace-only lines as blank lines
+
+In *Loose* mode, blank lines that only contain whitespace characters are treated as blank lines.
+In *Strict* mode, a blank line my only contain a line-break (`\r\n` or `\n`).
+
+The following commit message is valid in *Loose* mode but invalid in *Strict* mode
+(there is whitespace in the second line of the commit message):
+
+```txt
+feat: New Feature
+       
+Description of the feature
+```
+
+## See Also
+
+- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)
+- [Configuration - Parser Mode](./configuration.md#parser-mode)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,7 @@ like this:
 - [Template Name](#template-name)
 - [Markdown Preset (Default Template)](#markdown-preset-default-template)
 - [Entry types](#entry-types)
+- [Parser Mode](#parser-mode)
 
 ### Scopes
 
@@ -666,7 +667,7 @@ For example, to include all changes of type `feat`, `fix` and `docs`, you must i
 
 #### Example
 
-The follwoing example shows ho to include changes of type `feat`, `fix` and `docs` in the change log:
+The following example shows how to include changes of type `feat`, `fix` and `docs` in the change log:
 
 ```json
 {
@@ -680,6 +681,65 @@ The follwoing example shows ho to include changes of type `feat`, `fix` and `doc
 }
 ```
 
+### Parser Mode
+
+<table>
+    <tr>
+        <td><b>Setting</b></td>
+        <td><code>changelog:parser:mode</code></td>
+    </tr>
+    <tr>
+        <td><b>Environment Variable</b></td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td><b>Commandline Parameter</b></td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td><b>Default value</b></td>
+        <td>
+            <code>Loose</code>
+        </td>
+    </tr>
+    <tr>
+        <td><b>Allowed values</b></td>
+        <td>
+            <ul>
+                <li><code>Loose</code></li>
+                <li><code>Strict</code></li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <td><b>Version Support</b></td>
+        <td>0.2+</td>
+    </tr>
+</table>
+
+The "Parser Mode" setting controls how lenient the commit message parser treats commit messages.
+
+Available options are
+
+- `Loose` (default)
+- `Struct`
+
+For details, see [Commit Message Parser](./commit-message-parser.md)
+
+#### Example
+
+The following example sets the parser mode to `strict`:
+
+```json
+{
+    "changelog" : {
+        "parser" : {
+            "mode": "strict"
+        }
+    }
+}
+```
+
 ## See Also
 
 - [Commandline reference](./commandline-reference/index.md)
@@ -689,3 +749,4 @@ The follwoing example shows ho to include changes of type `feat`, `fix` and `doc
 - [Integrations](./integrations.md)
 - [NuGet Version Ranges](https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges)
 - [Templates](./templates.md)
+- [Commit Message Parser](./commit-message-parser.md)

--- a/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
+++ b/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
@@ -139,6 +139,9 @@ namespace Grynwald.ChangeLog.Test.Configuration
                     Assert.Equal(CommitType.BugFix, new CommitType(x.Type!));
                     Assert.Equal("Bug Fixes", x.DisplayName);
                 }));
+
+            yield return TestCase(config => Assert.NotNull(config.Parser));
+            yield return TestCase(config => Assert.Equal(ChangeLogConfiguration.ParserMode.Loose, config.Parser.Mode));
         }
 
         [Theory]
@@ -726,6 +729,21 @@ namespace Grynwald.ChangeLog.Test.Configuration
 
             Assert.Equal(entryTypes.Length, config.EntryTypes.Length);
             Assert.Collection(config.EntryTypes, assertions);
+        }
+
+        [Theory]
+        [EnumData]
+        public void ParserMode_can_be_set_in_configuration_file(ChangeLogConfiguration.ParserMode value)
+        {
+            // ARRANGE
+            PrepareConfiguration("parser:mode", value);
+
+            // ACT 
+            var config = ChangeLogConfigurationLoader.GetConfiguration(m_ConfigurationFilePath);
+
+            // ASSERT
+            Assert.NotNull(config.Parser);
+            Assert.Equal(value, config.Parser.Mode);
         }
     }
 }

--- a/src/ChangeLog.Test/ConventionalCommits/_Parser/CommitMessageParserTest.cs
+++ b/src/ChangeLog.Test/ConventionalCommits/_Parser/CommitMessageParserTest.cs
@@ -88,8 +88,6 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
                 );
             }
 
-            // TODO: Ignore trailing blank lines
-
             // single line body
             yield return MultiLineTestCase(
                 "T22",
@@ -309,6 +307,47 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
                 "Reviewed-by: Z",
                 "Footer2: description"
             );
+
+            //
+            // Trailing blank lines are ignored (whitespace-only lines are treated as blank lines as well)
+            //
+
+            yield return MultiLineTestCase(
+                "T35",
+                new CommitMessage(new CommitMessageHeader(CommitType.Feature, "Some Description")),
+                "feat: Some Description",
+                "  ",
+                ""
+            );
+
+            yield return MultiLineTestCase(
+                 "T36",
+                 new CommitMessage(
+                     header: new CommitMessageHeader(CommitType.Feature, "Some Description"),
+                     body: new[] { "Message Body\r\n" }
+                 ),
+                 "feat: Some Description",
+                 "  ",
+                 "Message Body",
+                 "",
+                 "  "
+             );
+
+            yield return MultiLineTestCase(
+                 "T37",
+                 new CommitMessage(
+                     header: new CommitMessageHeader(CommitType.Feature, "Some Description"),
+                     body: new[] { "Message Body\r\n" },
+                     footers: new[] { new CommitMessageFooter(new CommitMessageFooterName("name"), "value") }
+                 ),
+                 "feat: Some Description",
+                 "  ",
+                 "Message Body",
+                 "",
+                 "name: value",
+                 "",
+                 "  "
+             );
         }
 
         public static IEnumerable<object[]> InvalidParserTestCases()
@@ -354,7 +393,7 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
             // multiple blank lines between header and body
             yield return MultiLineTestCase(
                 "T18",
-                lineNumber: 3, columnNumber: 1,
+                lineNumber: 4, columnNumber: 1,
                 "type: Description",
                 "",
                 "",
@@ -364,7 +403,7 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
             // multiple blank lines between body and footer
             yield return MultiLineTestCase(
                 "T19",
-                lineNumber: 6, columnNumber: 1,
+                lineNumber: 7, columnNumber: 1,
                 "type: Description",
                 "",
                 "Body 1",
@@ -411,6 +450,7 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
             m_OutputHelper.WriteLine($"Test case {id}");
 
             var ex = Assert.ThrowsAny<ParserException>(() => CommitMessageParser.Parse(input));
+            m_OutputHelper.WriteLine($"Exception Message: {ex.Message}");
             Assert.Equal(lineNumber, ex.LineNumber);
             Assert.Equal(columnNumber, ex.ColumnNumber);
         }

--- a/src/ChangeLog.Test/ConventionalCommits/_Parser/CommitMessageParserTest.cs
+++ b/src/ChangeLog.Test/ConventionalCommits/_Parser/CommitMessageParserTest.cs
@@ -400,6 +400,39 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
                  "\t",
                  "name: value"
              );
+
+            // Blank lines between footers
+            yield return MultiLineTestCase(
+                "T41",
+                new CommitMessage(
+                    header: new CommitMessageHeader(
+                        type: new CommitType("type"),
+                        description: "Description",
+                        scope: null,
+                        isBreakingChange: false
+                    ),
+                    body: new[] { "Message Body\r\n" },
+                    footers: new[]
+                    {
+                        new CommitMessageFooter(name: new CommitMessageFooterName("Footer1"), value: "Footer Description1"),
+                        new CommitMessageFooter(name: new CommitMessageFooterName("Footer2"), value: "Footer Description2"),
+                        new CommitMessageFooter(name: new CommitMessageFooterName("Footer3"), value: "Footer Description3"),
+                        new CommitMessageFooter(name: new CommitMessageFooterName("Footer4"), value: "Footer Description4")
+                    }
+                ),
+                "type: Description",
+                "",
+                "Message Body",
+                "",
+                "Footer1: Footer Description1",
+                "",
+                "Footer2: Footer Description2",
+                "Footer3: Footer Description3",
+                "",
+                "\t",
+                " ",
+                "Footer4: Footer Description4"
+            );
         }
 
         public static IEnumerable<object[]> InvalidParserTestCases()

--- a/src/ChangeLog.Test/ConventionalCommits/_Parser/CommitMessageParserTest.cs
+++ b/src/ChangeLog.Test/ConventionalCommits/_Parser/CommitMessageParserTest.cs
@@ -348,6 +348,58 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
                  "",
                  "  "
              );
+
+
+            //
+            // Multiple blank lines between sections
+            //
+
+            // multiple blank lines between header and body
+            yield return MultiLineTestCase(
+                 "T38",
+                 new CommitMessage(
+                     header: new CommitMessageHeader(CommitType.Feature, "Some Description"),
+                     body: new[] { "Message Body\r\n" }
+                 ),
+                 "feat: Some Description",
+                 "  ",
+                 "",
+                 "\t",
+                 "Message Body"
+             );
+
+            // multiple blank lines between paragraphs
+            yield return MultiLineTestCase(
+                 "T39",
+                 new CommitMessage(
+                     header: new CommitMessageHeader(CommitType.Feature, "Some Description"),
+                     body: new[] { "Line1\r\n", "Line2\r\n" }
+                 ),
+                 "feat: Some Description",
+                 "",
+                 "Line1",
+                 "  ",
+                 "",
+                 "\t",
+                 "Line2"
+             );
+
+            // multiple blank lines between body and footers
+            yield return MultiLineTestCase(
+                 "T40",
+                 new CommitMessage(
+                     header: new CommitMessageHeader(CommitType.Feature, "Some Description"),
+                     body: new[] { "Message Body\r\n" },
+                     footers: new[] { new CommitMessageFooter(new CommitMessageFooterName("name"), "value") }
+                 ),
+                 "feat: Some Description",
+                 "",
+                 "Message Body",
+                 "  ",
+                 "",
+                 "\t",
+                 "name: value"
+             );
         }
 
         public static IEnumerable<object[]> InvalidParserTestCases()
@@ -383,35 +435,12 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
             yield return TestCase($"T11", lineNumber: 1, columnNumber: 14, $"feat(scope):  ");
 
             // missing description in footer            
-            yield return TestCase($"T12", lineNumber: 3, columnNumber: 9, $"type(scope): Description\r\n\r\nFooter: ");
-            yield return TestCase($"T13", lineNumber: 3, columnNumber: 18, $"type(scope): Description\r\n\r\nBREAKING CHANGE: ");
-            yield return TestCase($"T14", lineNumber: 3, columnNumber: 9, $"type(scope): Description\r\n\r\nFooter: \t");
-            yield return TestCase($"T15", lineNumber: 3, columnNumber: 9, $"type(scope): Description\r\n\r\nFooter:  ");
-            yield return TestCase($"T16", lineNumber: 3, columnNumber: 8, $"type(scope): Description\r\n\r\nFooter # ");
-            yield return TestCase($"T17", lineNumber: 3, columnNumber: 17, $"type(scope): Description\r\n\r\nBREAKING CHANGE #\t");
-
-            // multiple blank lines between header and body
-            yield return MultiLineTestCase(
-                "T18",
-                lineNumber: 4, columnNumber: 1,
-                "type: Description",
-                "",
-                "",
-                "Body"
-            );
-
-            // multiple blank lines between body and footer
-            yield return MultiLineTestCase(
-                "T19",
-                lineNumber: 7, columnNumber: 1,
-                "type: Description",
-                "",
-                "Body 1",
-                "Body 2",
-                "",
-                "",
-                "Footer: Value"
-            );
+            yield return TestCase($"T12", lineNumber: 3, columnNumber: 9, "type(scope): Description\r\n\r\nFooter: ");
+            yield return TestCase($"T13", lineNumber: 3, columnNumber: 18, "type(scope): Description\r\n\r\nBREAKING CHANGE: ");
+            yield return TestCase($"T14", lineNumber: 3, columnNumber: 9, "type(scope): Description\r\n\r\nFooter: \t");
+            yield return TestCase($"T15", lineNumber: 3, columnNumber: 9, "type(scope): Description\r\n\r\nFooter:  ");
+            yield return TestCase($"T16", lineNumber: 3, columnNumber: 8, "type(scope): Description\r\n\r\nFooter # ");
+            yield return TestCase($"T17", lineNumber: 3, columnNumber: 17, "type(scope): Description\r\n\r\nBREAKING CHANGE #\t");
 
             // footer with empty description
             yield return MultiLineTestCase(

--- a/src/ChangeLog.Test/ConventionalCommits/_Parser/LineTokenizerTest.cs
+++ b/src/ChangeLog.Test/ConventionalCommits/_Parser/LineTokenizerTest.cs
@@ -13,12 +13,14 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
     {
         public static IEnumerable<object[]> TokenizerTestCases()
         {
-            static object[] testCase(string input, params LineToken[] tokens) =>
-                new object[]
+            static object[] testCase(string input, params LineToken[] tokens)
+            {
+                return new object[]
                 {
                     input,
                     tokens.Select(t => new XunitSerializableLineToken(t)).ToArray()
                 };
+            }
 
             // empty string
             yield return testCase("", LineToken.Eof(1));
@@ -52,6 +54,33 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
                 yield return testCase(
                     "Line1" + lineBreak + lineBreak + "Line2" + lineBreak,
                     LineToken.Line("Line1", 1), LineToken.Blank(2), LineToken.Line("Line2", 3), LineToken.Eof(4)
+                );
+            }
+
+            // whitespace lines are treated as empty lines
+            foreach (var whitespaceLine in new[] { " ", "\t", "  " })
+            {
+                yield return testCase(
+                    "Line1\r\n" +
+                    whitespaceLine + "\r\n" +
+                    "Line3",
+                    LineToken.Line("Line1", 1), LineToken.Blank(2), LineToken.Line("Line3", 3), LineToken.Eof(4)
+                );
+
+                yield return testCase(
+                    "Line1\r\n" +
+                    whitespaceLine + "\r\n" +
+                    whitespaceLine + "\r\n" +
+                    "Line4",
+                    LineToken.Line("Line1", 1), LineToken.Blank(2), LineToken.Blank(3), LineToken.Line("Line4", 4), LineToken.Eof(5)
+                );
+
+                yield return testCase(
+                    "Line1\r\n" +
+                    whitespaceLine + "\r\n" +
+                    "Line3\r\n" +
+                    whitespaceLine,
+                    LineToken.Line("Line1", 1), LineToken.Blank(2), LineToken.Line("Line3", 3), LineToken.Blank(4), LineToken.Eof(5)
                 );
             }
         }

--- a/src/ChangeLog.Test/ConventionalCommits/_Parser/LineTokenizerTest.cs
+++ b/src/ChangeLog.Test/ConventionalCommits/_Parser/LineTokenizerTest.cs
@@ -13,81 +13,146 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
     {
         public static IEnumerable<object[]> TokenizerTestCases()
         {
-            static object[] testCase(string input, params LineToken[] tokens)
+            static object[] TestCase(string input, bool treatWhitespaceOnlyLinesAsBlankLines, params LineToken[] tokens)
             {
                 return new object[]
                 {
                     input,
+                    treatWhitespaceOnlyLinesAsBlankLines,
                     tokens.Select(t => new XunitSerializableLineToken(t)).ToArray()
                 };
             }
 
             // empty string
-            yield return testCase("", LineToken.Eof(1));
+            yield return TestCase("", treatWhitespaceOnlyLinesAsBlankLines: false, LineToken.Eof(1));
 
             // 1 line without line break
-            yield return testCase("Line1", LineToken.Line("Line1", 1), LineToken.Eof(2));
+            yield return TestCase("Line1", treatWhitespaceOnlyLinesAsBlankLines: false, LineToken.Line("Line1", 1), LineToken.Eof(2));
 
             foreach (var lineBreak in new[] { "\n", "\r\n" })
             {
                 // just a line break
-                yield return testCase(lineBreak, LineToken.Blank(1), LineToken.Eof(2));
+                yield return TestCase(lineBreak, treatWhitespaceOnlyLinesAsBlankLines: false, LineToken.Blank(1), LineToken.Eof(2));
 
                 // 1 line with line break
-                yield return testCase("Line1" + lineBreak, LineToken.Line("Line1", 1), LineToken.Eof(2));
+                yield return TestCase("Line1" + lineBreak, treatWhitespaceOnlyLinesAsBlankLines: false, LineToken.Line("Line1", 1), LineToken.Eof(2));
 
                 // 2 lines (with and without trailing line break)
-                yield return testCase(
+                yield return TestCase(
                     "Line1" + lineBreak + "Line2" + lineBreak,
+                    treatWhitespaceOnlyLinesAsBlankLines: false,
                     LineToken.Line("Line1", 1), LineToken.Line("Line2", 2), LineToken.Eof(3)
                 );
-                yield return testCase(
+                yield return TestCase(
                     "Line1" + lineBreak + "Line2",
+                    treatWhitespaceOnlyLinesAsBlankLines: false,
                     LineToken.Line("Line1", 1), LineToken.Line("Line2", 2), LineToken.Eof(3)
                 );
 
                 // 2 lines with blank line in between (with and without trailing line break)
-                yield return testCase(
+                yield return TestCase(
                     "Line1" + lineBreak + lineBreak + "Line2",
+                    treatWhitespaceOnlyLinesAsBlankLines: false,
                     LineToken.Line("Line1", 1), LineToken.Blank(2), LineToken.Line("Line2", 3), LineToken.Eof(4)
                 );
-                yield return testCase(
+                yield return TestCase(
                     "Line1" + lineBreak + lineBreak + "Line2" + lineBreak,
+                    treatWhitespaceOnlyLinesAsBlankLines: false,
                     LineToken.Line("Line1", 1), LineToken.Blank(2), LineToken.Line("Line2", 3), LineToken.Eof(4)
                 );
             }
 
-            // whitespace lines are treated as empty lines
+            // trailing blank line
+            yield return TestCase(
+                "feat: Some Description\r\n" +
+                "\r\n" +
+                "Message Body\r\n" +
+                "\r\n" +
+                "name: value\r\n" +
+                "\r\n",
+                treatWhitespaceOnlyLinesAsBlankLines: false,
+                LineToken.Line("feat: Some Description", 1),
+                LineToken.Blank(2),
+                LineToken.Line("Message Body", 3),
+                LineToken.Blank(4),
+                LineToken.Line("name: value", 5),
+                LineToken.Blank(6),
+                LineToken.Eof(7)
+            );
+
+            // trailing blank line
+            yield return TestCase(
+                "feat: Some Description\r\n" +
+                "\r\n",
+                treatWhitespaceOnlyLinesAsBlankLines: false,
+                LineToken.Line("feat: Some Description", 1),
+                LineToken.Blank(2),
+                LineToken.Eof(3)
+            );
+
+            // In "looseMode", whitespace-only lines are treated as empty lines
+            // In strict mode, they are treated as regular lines
             foreach (var whitespaceLine in new[] { " ", "\t", "  " })
             {
-                yield return testCase(
+                yield return TestCase(
                     "Line1\r\n" +
                     whitespaceLine + "\r\n" +
                     "Line3",
+                    treatWhitespaceOnlyLinesAsBlankLines: true,
                     LineToken.Line("Line1", 1), LineToken.Blank(2), LineToken.Line("Line3", 3), LineToken.Eof(4)
                 );
 
-                yield return testCase(
+
+                yield return TestCase(
+                    "Line1\r\n" +
+                    whitespaceLine + "\r\n" +
+                    "Line3",
+                    treatWhitespaceOnlyLinesAsBlankLines: false,
+                    LineToken.Line("Line1", 1), LineToken.Line(whitespaceLine, 2), LineToken.Line("Line3", 3), LineToken.Eof(4)
+                );
+
+                yield return TestCase(
                     "Line1\r\n" +
                     whitespaceLine + "\r\n" +
                     whitespaceLine + "\r\n" +
                     "Line4",
+                    treatWhitespaceOnlyLinesAsBlankLines: true,
                     LineToken.Line("Line1", 1), LineToken.Blank(2), LineToken.Blank(3), LineToken.Line("Line4", 4), LineToken.Eof(5)
                 );
 
-                yield return testCase(
+                yield return TestCase(
+                    "Line1\r\n" +
+                    whitespaceLine + "\r\n" +
+                    whitespaceLine + "\r\n" +
+                    "Line4",
+                    treatWhitespaceOnlyLinesAsBlankLines: false,
+                    LineToken.Line("Line1", 1), LineToken.Line(whitespaceLine, 2), LineToken.Line(whitespaceLine, 3), LineToken.Line("Line4", 4), LineToken.Eof(5)
+                );
+
+                yield return TestCase(
                     "Line1\r\n" +
                     whitespaceLine + "\r\n" +
                     "Line3\r\n" +
                     whitespaceLine,
+                    treatWhitespaceOnlyLinesAsBlankLines: true,
                     LineToken.Line("Line1", 1), LineToken.Blank(2), LineToken.Line("Line3", 3), LineToken.Blank(4), LineToken.Eof(5)
                 );
+
+                yield return TestCase(
+                    "Line1\r\n" +
+                    whitespaceLine + "\r\n" +
+                    "Line3\r\n" +
+                    whitespaceLine,
+                    treatWhitespaceOnlyLinesAsBlankLines: false,
+                    LineToken.Line("Line1", 1), LineToken.Line(whitespaceLine, 2), LineToken.Line("Line3", 3), LineToken.Line(whitespaceLine, 4), LineToken.Eof(5)
+                );
             }
+
         }
 
         [Theory]
         [MemberData(nameof(TokenizerTestCases))]
-        public void GetTokens_returns_expected_tokens(string input, IEnumerable<XunitSerializableLineToken> expectedTokens)
+        public void GetTokens_returns_expected_tokens(string input, bool treatWhitespaceOnlyLinesAsBlankLines, IEnumerable<XunitSerializableLineToken> expectedTokens)
         {
             // ARRANGE
             var inspectors = expectedTokens
@@ -96,7 +161,7 @@ namespace Grynwald.ChangeLog.Test.ConventionalCommits
                 .ToArray();
 
             // ACT
-            var actualTokens = LineTokenizer.GetTokens(input).ToArray();
+            var actualTokens = LineTokenizer.GetTokens(input, treatWhitespaceOnlyLinesAsBlankLines).ToArray();
 
             // ASSERT
             Assert.Collection(actualTokens, inspectors);

--- a/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
+++ b/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
@@ -19,7 +19,6 @@ namespace Grynwald.ChangeLog.Configuration
             public string? DisplayName { get; set; }
         }
 
-
         public enum IntegrationProvider
         {
             None = 0,
@@ -78,6 +77,17 @@ namespace Grynwald.ChangeLog.Configuration
             public string? DisplayName { get; set; }
         }
 
+        public enum ParserMode
+        {
+            Strict,
+            Loose
+        }
+
+        public class ParserConfiguration
+        {
+            public ParserMode Mode { get; set; }
+        }
+
 
         public ScopeConfiguration[] Scopes { get; set; } = Array.Empty<ScopeConfiguration>();
 
@@ -98,6 +108,8 @@ namespace Grynwald.ChangeLog.Configuration
         public TemplateConfiguration Template { get; set; } = new TemplateConfiguration();
 
         public EntryTypeConfiguration[] EntryTypes { get; set; } = Array.Empty<EntryTypeConfiguration>();
+
+        public ParserConfiguration Parser { get; set; } = new ParserConfiguration();
 
 
         public string GetFullOutputPath()

--- a/src/ChangeLog/Configuration/defaultSettings.json
+++ b/src/ChangeLog/Configuration/defaultSettings.json
@@ -46,6 +46,10 @@
       "default": {
         "markdownPreset": "default"
       }
+    },
+
+    "parser": {
+      "mode" :  "loose"
     }
   }
 }

--- a/src/ChangeLog/ConventionalCommits/_Parser/CommitMessageParser.cs
+++ b/src/ChangeLog/ConventionalCommits/_Parser/CommitMessageParser.cs
@@ -122,6 +122,9 @@ namespace Grynwald.ChangeLog.ConventionalCommits
             while (TestAndMatchToken(LineTokenKind.Line, out var currentLine))
             {
                 footers.Add(FooterParser.Parse(currentLine));
+
+                // ignore blank lines between footers
+                MatchTokens(LineTokenKind.Blank, 0);
             }
             return footers;
         }

--- a/src/ChangeLog/ConventionalCommits/_Parser/CommitMessageParser.cs
+++ b/src/ChangeLog/ConventionalCommits/_Parser/CommitMessageParser.cs
@@ -60,6 +60,10 @@ namespace Grynwald.ChangeLog.ConventionalCommits
                 footers = ParseFooters();
             }
 
+            // Consume all trailing blank lines (ignored)
+            while (TestAndMatchToken(LineTokenKind.Blank, out _))
+            { }
+
             // Ensure all tokens were parsed
             MatchToken(LineTokenKind.Eof);
 

--- a/src/ChangeLog/ConventionalCommits/_Parser/LineTokenizer.cs
+++ b/src/ChangeLog/ConventionalCommits/_Parser/LineTokenizer.cs
@@ -33,7 +33,7 @@ namespace Grynwald.ChangeLog.ConventionalCommits
     /// </summary>
     internal static class LineTokenizer
     {
-        public static IEnumerable<LineToken> GetTokens(string input)
+        public static IEnumerable<LineToken> GetTokens(string input, bool treatWhitespaceOnlyLinesAsBlankLines)
         {
             if (input is null)
                 throw new ArgumentNullException(nameof(input));
@@ -44,8 +44,8 @@ namespace Grynwald.ChangeLog.ConventionalCommits
 
             LineToken GetCurrentToken()
             {
-                // Lines that consist only of whitespace characters are considered blank lines
-                if (currentLine.Length == 0 || currentLineIsWhitespace)
+                // In "Loose Mode", lines that consist only of whitespace characters are considered blank lines                
+                if (currentLine.Length == 0 || (treatWhitespaceOnlyLinesAsBlankLines && currentLineIsWhitespace))
                 {
                     // clear current value of line
                     currentLine.Clear();
@@ -90,6 +90,5 @@ namespace Grynwald.ChangeLog.ConventionalCommits
 
             yield return LineToken.Eof(lineNumber);
         }
-
     }
 }

--- a/src/ChangeLog/Tasks/ParseCommitsTask.cs
+++ b/src/ChangeLog/Tasks/ParseCommitsTask.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading.Tasks;
+using Grynwald.ChangeLog.Configuration;
 using Grynwald.ChangeLog.ConventionalCommits;
 using Grynwald.ChangeLog.Git;
 using Grynwald.ChangeLog.Model;
@@ -12,12 +12,14 @@ namespace Grynwald.ChangeLog.Tasks
     internal sealed class ParseCommitsTask : SynchronousChangeLogTask
     {
         private readonly ILogger<ParseCommitsTask> m_Logger;
+        private readonly ChangeLogConfiguration m_Configuration;
         private readonly IGitRepository m_Repository;
 
 
-        public ParseCommitsTask(ILogger<ParseCommitsTask> logger, IGitRepository repository)
+        public ParseCommitsTask(ILogger<ParseCommitsTask> logger, ChangeLogConfiguration configuration, IGitRepository repository)
         {
             m_Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            m_Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             m_Repository = repository ?? throw new ArgumentNullException(nameof(repository));
         }
 
@@ -59,9 +61,10 @@ namespace Grynwald.ChangeLog.Tasks
 
         private bool TryGetChangeLogEntry(GitCommit commit, [NotNullWhen(true)]out ChangeLogEntry? entry)
         {
+            var strictMode = m_Configuration.Parser.Mode == ChangeLogConfiguration.ParserMode.Strict;
             try
             {
-                var parsed = CommitMessageParser.Parse(commit.CommitMessage, strictMode: false);
+                var parsed = CommitMessageParser.Parse(commit.CommitMessage, strictMode);
                 entry = ChangeLogEntry.FromCommitMessage(commit, parsed);
                 return true;
             }

--- a/src/ChangeLog/Tasks/ParseCommitsTask.cs
+++ b/src/ChangeLog/Tasks/ParseCommitsTask.cs
@@ -61,7 +61,7 @@ namespace Grynwald.ChangeLog.Tasks
         {
             try
             {
-                var parsed = CommitMessageParser.Parse(commit.CommitMessage);
+                var parsed = CommitMessageParser.Parse(commit.CommitMessage, strictMode: false);
                 entry = ChangeLogEntry.FromCommitMessage(commit, parsed);
                 return true;
             }


### PR DESCRIPTION
- [x] Treat whitespace-only lines as blank lines
- [x] Ignore trailing blank lines
- [x] Allow duplicate blank lines between paragraphs and footers
- [ ] ~Allow multi-line footers~
- [x] Setting to switch between *strict* and *loose* modes