### PR TITLE
ci: Speed up post-build-jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -371,7 +371,7 @@ jobs:
       downloadPath: $(Build.ArtifactStagingDirectory)
 
   - powershell : |
-      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/nbgv.json" | ConvertFrom-Json
+      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/variables/nbgv.json" | ConvertFrom-Json
 
       $variableNames = $json | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
       foreach($name in $variableNames) {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -360,6 +360,7 @@ jobs:
   - Build_and_Test
 
   steps:
+  - checkout: none
 
   # Get artifacts (variables)
   - task: DownloadBuildArtifacts@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@
 #   - Pushes the NuGet package to MyGet
 #   - Assumes a Service Connection for MyGet was set up in the Team project running the pipeline
 #   - The name of the service connection is stored in the variable myget_ServiceConnectionName (defined below)
-#   - Only runs when building a release branch or the master branch
+#   - Only runs when building a release branch or the 'master' branch
 # - Publish_to_NuGet_org
 #   - Pushes the NuGet package to NuGet.org
 #   - Assumes a Service Connection for NuGet was set up in the Team project running the pipeline
@@ -16,7 +16,10 @@
 #   - The variable nuget_org_PackageName defines which package is produced by the pipeline
 # - Create_GitHub_Release
 #   - Creates a GitHub release for the build
-#   - Only runs if the build was published to NuGet.org
+#   - Only runs when building the a release branch and publishing to nuget.org succeeded
+# - Create_GitHub_Draft_Release
+#   - Creates a *DRAFT* release on GitHub
+#   - Only runs when building the 'master' branch
 
 trigger:
   - master
@@ -54,7 +57,7 @@ jobs:
 # Main Build and test job: Builds the projects and runs all tests
 - job: Build_and_Test
   displayName: Build and Test
-  pool: 
+  pool:
     vmImage: $(azuredevops_vmimage)
   steps:
 
@@ -89,18 +92,18 @@ jobs:
       # Caculate output path
       $outDirPath = Join-Path "$(Build.ArtifactStagingDirectory)" "$(artifactsName_Variables)"
       $outFilePath = Join-Path $outDirPath "nbgv.json"
-      
-      # Get version variables (the value of the 'CloudBuildAllVars' property in the JSON outpu of nbgv)      
+
+      # Get version variables (the value of the 'CloudBuildAllVars' property in the JSON output of nbgv)
       $json = Invoke-Expression "dotnet tool run nbgv -- get-version --format json" | ConvertFrom-Json
       if($LASTEXITCODE -ne 0) {
         throw "'nbgv get-version' completed with exit code $LASTEXITCODE"
       }
-      $json = $json.CloudBuildAllVars | ConvertTo-Json 
-      
-      # Create output directory      
+      $json = $json.CloudBuildAllVars | ConvertTo-Json
+
+      # Create output directory
       if(-not (Test-Path $outDirPath)) {
         New-Item -ItemType Directory -Path $outDirPath | Out-Null
-      } 
+      }
 
       # Save variables to file
       [System.IO.File]::WriteAllText($outFilePath, $json)
@@ -258,26 +261,31 @@ jobs:
     )
   steps:
 
-  # Install .NET Core SDK and runtime (version specified in global.json)
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
+  # Skip checkout of sources, all data required for this setp can be laoded from the previous job's artifacts
+  - checkout: none
+
+  # Get variables from Build job (the Build_an_Test job saves variables to a JSON files and publishes it as build artifact)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Artifacts: $(artifactsName_Variables)'
     inputs:
-      packageType: sdk
-      useGlobalJson: true
+      buildType: current
+      downloadType: single
+      artifactName: variables
+      downloadPath: $(Build.ArtifactStagingDirectory)
+  - powershell : |
+      # Load variables JSON file generated during build
+      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/$(artifactsName_Variables)/nbgv.json" | ConvertFrom-Json
 
-  # Restore local .NET Core tools
-  - task: DotNetCoreCLI@2
-    displayName: Restore local tools
-    inputs:
-      command: custom
-      custom: tool
-      arguments: restore
+      # for each variable, set the value as Azure Pipelines variable
+      $variableNames = $json | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+      foreach($variableName in $variableNames) {
+        $value = $json."$variableName"
+        Write-Host "Setting variable '$variableName' to '$value'"
+        Write-Host "##vso[task.setvariable variable=$variableName]$value"
+      }
+    displayName: Load version variables
 
-  # Set the build number using Nerdbank.GitVersioning
-  - script: dotnet tool run nbgv cloud --all-vars
-    displayName: Set Version
-
-  # Get artifacts
+  # Get artifacts (Changelog and Binaries/packages)
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Artifacts: $(artifactsName_Binaries)'
     inputs:
@@ -312,34 +320,40 @@ jobs:
 # Job to create a GitHub *DRAFT* release (only if a package was uploaded to myget.org)
 - job: Create_GitHub_Draft_Release
   displayName: Create GitHub DRAFT Release
-  pool: 
+  pool:
     vmImage: $(azuredevops_vmimage)
   # Only run if build was successful and a package was uploaded to nuget.org
   dependsOn:
   - Build_and_Test
   condition: eq(variables['build.sourceBranch'], 'refs/heads/master')
+
   steps:
 
-  # Install .NET Core SDK and runtime (version specified in global.json)
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
+  # Skip checkout of sources, all data required for this setp can be laoded from the previous job's artifacts
+  - checkout: none
+
+  # Get variables from Build job (the Build_an_Test job saves variables to a JSON files and publishes it as build artifact)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Artifacts: $(artifactsName_Variables)'
     inputs:
-      packageType: sdk
-      useGlobalJson: true
+      buildType: current
+      downloadType: single
+      artifactName: variables
+      downloadPath: $(Build.ArtifactStagingDirectory)
+  - powershell : |
+      # Load variables JSON file generated during build
+      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/$(artifactsName_Variables)/nbgv.json" | ConvertFrom-Json
 
-  # Restore local .NET Core tools
-  - task: DotNetCoreCLI@2
-    displayName: Restore local tools
-    inputs:
-      command: custom
-      custom: tool
-      arguments: restore
+      # for each variable, set the value as Azure Pipelines variable
+      $variableNames = $json | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+      foreach($variableName in $variableNames) {
+        $value = $json."$variableName"
+        Write-Host "Setting variable '$variableName' to '$value'"
+        Write-Host "##vso[task.setvariable variable=$variableName]$value"
+      }
+    displayName: Load version variables
 
-  # Set the build number using Nerdbank.GitVersioning
-  - script: dotnet tool run nbgv cloud --all-vars
-    displayName: Set Version
-
-  # Get artifacts (changelog)
+  # Download changelog (gernated by the Build_and_Test job and published as build artifact)
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Artifacts: $(artifactsName_ChangeLog)'
     inputs:
@@ -363,41 +377,3 @@ jobs:
       releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(artifactsName_ChangeLog)/changelog.md
       addChangeLog: false
       isDraft: true
-
-
-- job: Test_Job
-  displayName: Test Job
-  pool: 
-    vmImage: $(azuredevops_vmimage)
-  # Only run if build was successful and a package was uploaded to nuget.org
-  dependsOn:
-  - Build_and_Test
-
-  steps:
-  - checkout: none
-
-  # Get artifacts (variables)
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: Variables'
-    inputs:
-      buildType: current
-      downloadType: single
-      artifactName: variables
-      downloadPath: $(Build.ArtifactStagingDirectory)
-
-  - powershell : |
-      # Load variables JSON file generated during build      
-      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/$(artifactsName_Variables)/nbgv.json" | ConvertFrom-Json
-
-      # for each variable, set the value as Azure Pipelines variable
-      $variableNames = $json | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
-      foreach($variableName in $variableNames) {
-        $value = $json."$variableName"
-        Write-Host "Setting variable '$variableName' to '$value'"
-        Write-Host "##vso[task.setvariable variable=$variableName]$value"
-      }
-    displayName: Load version variables
-
-  - powershell : |
-      Write-Host "NBGV_NuGetPackageVersion is $(NBGV_NuGetPackageVersion)"
-    displayName: "Print NBGV_NuGetPackageVersion"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -349,3 +349,38 @@ jobs:
       releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(artifactsName_ChangeLog)/changelog.md
       addChangeLog: false
       isDraft: true
+
+
+- job: Test_Job
+  displayName: Test Job
+  pool: 
+    vmImage: $(azuredevops_vmimage)
+  # Only run if build was successful and a package was uploaded to nuget.org
+  dependsOn:
+  - Build_and_Test
+
+  steps:
+
+  # Get artifacts (variables)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Artifacts: Variables'
+    inputs:
+      buildType: current
+      downloadType: single
+      artifactName: variables
+      downloadPath: $(Build.ArtifactStagingDirectory)
+
+  - powershell : |
+      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/nbgv.json" | ConvertFrom-Json
+
+      $variableNames = $json | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+      foreach($name in $variableNames) {
+        $value = $json."$name"
+        Write-Host "Setting variable '$name' to '$value'"
+        Write-Host ""##vso[task.setvariable variable=$name]$value""
+      }
+    displayName: Load variables
+
+  - powershell : |
+      Write-Host "NBGV_GitCommitDate is $(NBGV_GitCommitDate)"
+    displayName: "Print variable value"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,6 +198,10 @@ jobs:
   dependsOn: Build_and_Test
   condition: and(succeeded('Build_and_Test'), or(eq(variables['build.sourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') ))
   steps:
+
+  # Skip checkout of sources, all data required for this step can be laoded from the previous job's artifacts
+  - checkout: none  
+  
   # Get artifacts
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Artifacts: $(artifactsName_Binaries)'
@@ -206,6 +210,7 @@ jobs:
       downloadType: single
       artifactName: $(artifactsName_Binaries)
       downloadPath: $(Build.ArtifactStagingDirectory)
+  
   # Upload to MyGet.org
   - task: NuGetCommand@2
     displayName: "Upload package"
@@ -228,6 +233,10 @@ jobs:
       startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
     )
   steps:
+  
+  # Skip checkout of sources, all data required for this step can be laoded from the previous job's artifacts
+  - checkout: none
+  
   # Get artifacts
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Artifacts: $(artifactsName_Binaries)'
@@ -236,6 +245,7 @@ jobs:
       downloadType: single
       artifactName: $(artifactsName_Binaries)
       downloadPath: $(Build.ArtifactStagingDirectory)
+  
   # Upload to NuGet.org
   - task: NuGetCommand@2
     displayName: 'Upload package to NuGet.org'
@@ -261,7 +271,7 @@ jobs:
     )
   steps:
 
-  # Skip checkout of sources, all data required for this setp can be laoded from the previous job's artifacts
+  # Skip checkout of sources, all data required for this step can be laoded from the previous job's artifacts
   - checkout: none
 
   # Get variables from Build job (the Build_an_Test job saves variables to a JSON files and publishes it as build artifact)
@@ -329,7 +339,7 @@ jobs:
 
   steps:
 
-  # Skip checkout of sources, all data required for this setp can be laoded from the previous job's artifacts
+  # Skip checkout of sources, all data required for this step can be laoded from the previous job's artifacts
   - checkout: none
 
   # Get variables from Build job (the Build_an_Test job saves variables to a JSON files and publishes it as build artifact)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,10 +161,16 @@ jobs:
         --output $(Build.ArtifactStagingDirectory) 
         --no-build 
         /warnaserror        
-  - task: PublishBuildArtifacts@1
+  # Use a inline Powershell script for publishing artifacts instead of the built-in PublishBuildArtifacts task
+  # because the built-in task does not support wildcards and the artifacts staging directory contains other 
+  # artifacts as well (e.g. the variables JSON file published as the 'Variables' artifacts)
+  - powershell: |
+      $packageFiles = Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)" -Filter "*.nupkg"
+      foreach($packageFile in $packageFiles) {
+        Write-Host "Publishing Artifact '$($packageFile.FullName)'"
+        Write-Host "##vso[artifact.upload artifactname=$(artifactsName_Binaries)]$($packageFile.FullName)"
+      }
     displayName: 'Publish Artifacts: $(artifactsName_Binaries)'
-    inputs:
-      artifactName: $(artifactsName_Binaries)
 
   # Generate changelog and publish as build artifact
   - task: DotNetCoreCLI@2
@@ -254,7 +260,7 @@ jobs:
       nugetFeedType: external
       publishFeedCredentials: $(nuget_org_ServiceConnectionName)
 
-# Job to create a GitHub release (only if a package was uploaded to NuGet.org)
+# Job to create a GitHub release (only when building a release branch and the package was uploaded to NuGet.org)
 - job: Create_GitHub_Release
   displayName: Create GitHub Release
   pool: 
@@ -327,7 +333,7 @@ jobs:
       assets: $(Build.ArtifactStagingDirectory)/$(artifactsName_Binaries)/*.nupkg
       addChangeLog: false
 
-# Job to create a GitHub *DRAFT* release (only if a package was uploaded to myget.org)
+# Job to create a GitHub *DRAFT* release (only when building the 'master' branch)
 - job: Create_GitHub_Draft_Release
   displayName: Create GitHub DRAFT Release
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,6 +83,14 @@ jobs:
   - script: dotnet tool run nbgv cloud --all-vars
     displayName: Set Version
 
+  # Save nbgv variables as json artifac
+  - powershell: |
+      $tempPath = [System.IO.Path]::GetTempFileName()
+      $json = Invoke-Expression "dotnet tool run nbgv -- get-version --format json" | ConvertFrom-Json
+      $json = $json.CloudBuildAllVars | ConvertTo-Json 
+      [System.IO.File]::WriteAllText($tempPath, $json)
+      Write-Host "##vso[artifact.upload artifactname=variables]$tempPath"
+
   # Check the formatting using dotnet-format
   - script: dotnet format ./src --folder --check
     displayName: Check code formatting

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -394,10 +394,10 @@ jobs:
       foreach($variableName in $variableNames) {
         $value = $json."$variableName"
         Write-Host "Setting variable '$variableName' to '$value'"
-        Write-Host ""##vso[task.setvariable variable=$variableName]$value""
+        Write-Host "##vso[task.setvariable variable=$variableName]$value"
       }
     displayName: Load version variables
 
   - powershell : |
-      Write-Host "NBGV_NuGetPackageVersion is $($env:NBGV_NuGetPackageVersion)"
+      Write-Host "NBGV_NuGetPackageVersion is $(NBGV_NuGetPackageVersion)"
     displayName: "Print NBGV_NuGetPackageVersion"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,8 +31,9 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE : true    # do not populate NuGet caches on build agents (VM will be deleted afterwards anyways)
   configuration: Release                      # the configuration (Debug/Release) to build
   solutionPath : src/ChangeLog.sln            # The path of the solution to be built
-  artifactsName_Binaries: Binaries
-  artifactsName_ChangeLog: ChangeLog
+  Artifacts.Binaries.Name: Binaries
+  Artifacts.Changelog.Name: ChangeLog
+  Artifacts.Variables.Name: Variables
 
   # MyGet.org settings
   myget_ServiceConnectionName: 'MyGet - ap0llo-changelog'  # the name of the Azure DevOps service connection to use for MyGet.org
@@ -83,17 +84,30 @@ jobs:
   - script: dotnet tool run nbgv cloud --all-vars
     displayName: Set Version
 
-  # Save nbgv variables as json artifac
+  # Save nbgv variables as JSON artifact
   - powershell: |
-      $variableOutputPath = "$(Build.ArtifactStagingDirectory)/nbgv.json"
+      # Caculate output path
+      $outDirPath = Join-Path "$(Build.ArtifactStagingDirectory)" "$(Artifacts.Variables.Name)"
+      $outFilePath = Join-Path $outDirPath "nbgv.json"
+      
+      # Get version variables (the value of the 'CloudBuildAllVars' property in the JSON outpu of nbgv)      
       $json = Invoke-Expression "dotnet tool run nbgv -- get-version --format json" | ConvertFrom-Json
+      if($LASTEXITCODE -ne 0) {
+        throw "'nbgv get-version' completed with exit code $LASTEXITCODE"
+      }
       $json = $json.CloudBuildAllVars | ConvertTo-Json 
-      [System.IO.File]::WriteAllText($variableOutputPath, $json)
-      Write-Host "##vso[artifact.upload artifactname=variables]$variableOutputPath"
+      
+      # Create output directory      
+      if(-not (Test-Path $outDirPath)) {
+        New-Item -ItemType Directory -Path $outDirPath | Out-Null
+      } 
 
-      $variableOutputPath2 = "$(Build.ArtifactStagingDirectory)/nbgv2.json"
-      cp $variableOutputPath $variableOutputPath2
-      Write-Host "##vso[artifact.upload artifactname=variables]$variableOutputPath2"      
+      # Save variables to file
+      [System.IO.File]::WriteAllText($outFilePath, $json)
+
+      # Publish artifacts
+      Write-Host "##vso[artifact.upload artifactname=$(Artifacts.Variables.Name)]$outFilePath"
+    displayName: Save version variables
 
   # Check the formatting using dotnet-format
   - script: dotnet format ./src --folder --check
@@ -145,9 +159,9 @@ jobs:
         --no-build 
         /warnaserror        
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifacts: $(artifactsName_Binaries)'
+    displayName: 'Publish Artifacts: $(Artifacts.Binaries.Name)'
     inputs:
-      artifactName: $(artifactsName_Binaries)
+      artifactName: $(Artifacts.Binaries.Name)
 
   # Generate changelog and publish as build artifact
   - task: DotNetCoreCLI@2
@@ -167,10 +181,10 @@ jobs:
       CHANGELOG__INTEGRATIONS__GITHUB__ACCESSTOKEN: $(GitHub.AccessToken)
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifacts: $(artifactsName_ChangeLog)'
+    displayName: 'Publish Artifacts: $(Artifacts.Changelog.Name)'
     inputs:
       pathToPublish: $(Build.StagingDirectory)/changelog.md
-      artifactName: $(artifactsName_ChangeLog)
+      artifactName: $(Artifacts.Changelog.Name)
 
 # Job to push package to MyGet.org after build
 - job: Publish_to_MyGet
@@ -183,11 +197,11 @@ jobs:
   steps:
   # Get artifacts
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(artifactsName_Binaries)'
+    displayName: 'Download Artifacts: $(Artifacts.Binaries.Name)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(artifactsName_Binaries)
+      artifactName: $(Artifacts.Binaries.Name)
       downloadPath: $(Build.ArtifactStagingDirectory)
   # Upload to MyGet.org
   - task: NuGetCommand@2
@@ -213,11 +227,11 @@ jobs:
   steps:
   # Get artifacts
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(artifactsName_Binaries)'
+    displayName: 'Download Artifacts: $(Artifacts.Binaries.Name)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(artifactsName_Binaries)
+      artifactName: $(Artifacts.Binaries.Name)
       downloadPath: $(Build.ArtifactStagingDirectory)
   # Upload to NuGet.org
   - task: NuGetCommand@2
@@ -265,18 +279,18 @@ jobs:
 
   # Get artifacts
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(artifactsName_Binaries)'
+    displayName: 'Download Artifacts: $(Artifacts.Binaries.Name)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(artifactsName_Binaries)
+      artifactName: $(Artifacts.Binaries.Name)
       downloadPath: $(Build.ArtifactStagingDirectory)
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(artifactsName_ChangeLog)'
+    displayName: 'Download Artifacts: $(Artifacts.Changelog.Name)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(artifactsName_ChangeLog)
+      artifactName: $(Artifacts.Changelog.Name)
       downloadPath: $(Build.ArtifactStagingDirectory)
 
   # Create GitHub release
@@ -291,8 +305,8 @@ jobs:
       tag: v$(NBGV_NuGetPackageVersion)
       title: v$(NBGV_NuGetPackageVersion)
       releaseNotesSource: file
-      releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(artifactsName_ChangeLog)/changelog.md
-      assets: $(Build.ArtifactStagingDirectory)/$(artifactsName_Binaries)/*.nupkg
+      releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(Artifacts.Changelog.Name)/changelog.md
+      assets: $(Build.ArtifactStagingDirectory)/$(Artifacts.Binaries.Name)/*.nupkg
       addChangeLog: false
 
 # Job to create a GitHub *DRAFT* release (only if a package was uploaded to myget.org)
@@ -327,11 +341,11 @@ jobs:
 
   # Get artifacts (changelog)
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(artifactsName_ChangeLog)'
+    displayName: 'Download Artifacts: $(Artifacts.Changelog.Name)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(artifactsName_ChangeLog)
+      artifactName: $(Artifacts.Changelog.Name)
       downloadPath: $(Build.ArtifactStagingDirectory)
 
   # Create GitHub *DRAFT* release
@@ -346,7 +360,7 @@ jobs:
       tag: vNext
       title: v$(NBGV_NuGetPackageVersion)
       releaseNotesSource: file
-      releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(artifactsName_ChangeLog)/changelog.md
+      releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(Artifacts.Changelog.Name)/changelog.md
       addChangeLog: false
       isDraft: true
 
@@ -372,16 +386,18 @@ jobs:
       downloadPath: $(Build.ArtifactStagingDirectory)
 
   - powershell : |
-      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/variables/nbgv.json" | ConvertFrom-Json
+      # Load variables JSON file generated during build      
+      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/$(Artifacts.Variables.Name)/nbgv.json" | ConvertFrom-Json
 
+      # for each variable, set the value as Azure Pipelines variable
       $variableNames = $json | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
-      foreach($name in $variableNames) {
-        $value = $json."$name"
-        Write-Host "Setting variable '$name' to '$value'"
-        Write-Host ""##vso[task.setvariable variable=$name]$value""
+      foreach($variableName in $variableNames) {
+        $value = $json."$variableName"
+        Write-Host "Setting variable '$variableName' to '$value'"
+        Write-Host ""##vso[task.setvariable variable=$variableName]$value""
       }
-    displayName: Load variables
+    displayName: Load version variables
 
   - powershell : |
-      Write-Host "NBGV_GitCommitDate is $(NBGV_GitCommitDate)"
-    displayName: "Print variable value"
+      Write-Host "NBGV_NuGetPackageVersion is $($env:NBGV_NuGetPackageVersion)"
+    displayName: "Print NBGV_NuGetPackageVersion"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,11 +85,15 @@ jobs:
 
   # Save nbgv variables as json artifac
   - powershell: |
-      $tempPath = [System.IO.Path]::GetTempFileName()
+      $variableOutputPath = "$(Build.ArtifactStagingDirectory)/nbgv.json"
       $json = Invoke-Expression "dotnet tool run nbgv -- get-version --format json" | ConvertFrom-Json
       $json = $json.CloudBuildAllVars | ConvertTo-Json 
-      [System.IO.File]::WriteAllText($tempPath, $json)
-      Write-Host "##vso[artifact.upload artifactname=variables]$tempPath"
+      [System.IO.File]::WriteAllText($variableOutputPath, $json)
+      Write-Host "##vso[artifact.upload artifactname=variables]$variableOutputPath"
+
+      $variableOutputPath2 = "$(Build.ArtifactStagingDirectory)/nbgv2.json"
+      cp $variableOutputPath $variableOutputPath2
+      Write-Host "##vso[artifact.upload artifactname=variables]$variableOutputPath2"      
 
   # Check the formatting using dotnet-format
   - script: dotnet format ./src --folder --check

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,9 +31,9 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE : true    # do not populate NuGet caches on build agents (VM will be deleted afterwards anyways)
   configuration: Release                      # the configuration (Debug/Release) to build
   solutionPath : src/ChangeLog.sln            # The path of the solution to be built
-  Artifacts.Binaries.Name: Binaries
-  Artifacts.Changelog.Name: ChangeLog
-  Artifacts.Variables.Name: Variables
+  artifactsName_Binaries: Binaries
+  artifactsName_ChangeLog: ChangeLog
+  artifactsName_Variables: Variables
 
   # MyGet.org settings
   myget_ServiceConnectionName: 'MyGet - ap0llo-changelog'  # the name of the Azure DevOps service connection to use for MyGet.org
@@ -87,7 +87,7 @@ jobs:
   # Save nbgv variables as JSON artifact
   - powershell: |
       # Caculate output path
-      $outDirPath = Join-Path "$(Build.ArtifactStagingDirectory)" "$(Artifacts.Variables.Name)"
+      $outDirPath = Join-Path "$(Build.ArtifactStagingDirectory)" "$(artifactsName_Variables)"
       $outFilePath = Join-Path $outDirPath "nbgv.json"
       
       # Get version variables (the value of the 'CloudBuildAllVars' property in the JSON outpu of nbgv)      
@@ -106,7 +106,7 @@ jobs:
       [System.IO.File]::WriteAllText($outFilePath, $json)
 
       # Publish artifacts
-      Write-Host "##vso[artifact.upload artifactname=$(Artifacts.Variables.Name)]$outFilePath"
+      Write-Host "##vso[artifact.upload artifactname=$(artifactsName_Variables)]$outFilePath"
     displayName: Save version variables
 
   # Check the formatting using dotnet-format
@@ -159,9 +159,9 @@ jobs:
         --no-build 
         /warnaserror        
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifacts: $(Artifacts.Binaries.Name)'
+    displayName: 'Publish Artifacts: $(artifactsName_Binaries)'
     inputs:
-      artifactName: $(Artifacts.Binaries.Name)
+      artifactName: $(artifactsName_Binaries)
 
   # Generate changelog and publish as build artifact
   - task: DotNetCoreCLI@2
@@ -181,10 +181,10 @@ jobs:
       CHANGELOG__INTEGRATIONS__GITHUB__ACCESSTOKEN: $(GitHub.AccessToken)
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifacts: $(Artifacts.Changelog.Name)'
+    displayName: 'Publish Artifacts: $(artifactsName_ChangeLog)'
     inputs:
       pathToPublish: $(Build.StagingDirectory)/changelog.md
-      artifactName: $(Artifacts.Changelog.Name)
+      artifactName: $(artifactsName_ChangeLog)
 
 # Job to push package to MyGet.org after build
 - job: Publish_to_MyGet
@@ -197,11 +197,11 @@ jobs:
   steps:
   # Get artifacts
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(Artifacts.Binaries.Name)'
+    displayName: 'Download Artifacts: $(artifactsName_Binaries)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(Artifacts.Binaries.Name)
+      artifactName: $(artifactsName_Binaries)
       downloadPath: $(Build.ArtifactStagingDirectory)
   # Upload to MyGet.org
   - task: NuGetCommand@2
@@ -227,11 +227,11 @@ jobs:
   steps:
   # Get artifacts
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(Artifacts.Binaries.Name)'
+    displayName: 'Download Artifacts: $(artifactsName_Binaries)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(Artifacts.Binaries.Name)
+      artifactName: $(artifactsName_Binaries)
       downloadPath: $(Build.ArtifactStagingDirectory)
   # Upload to NuGet.org
   - task: NuGetCommand@2
@@ -279,18 +279,18 @@ jobs:
 
   # Get artifacts
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(Artifacts.Binaries.Name)'
+    displayName: 'Download Artifacts: $(artifactsName_Binaries)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(Artifacts.Binaries.Name)
+      artifactName: $(artifactsName_Binaries)
       downloadPath: $(Build.ArtifactStagingDirectory)
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(Artifacts.Changelog.Name)'
+    displayName: 'Download Artifacts: $(artifactsName_ChangeLog)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(Artifacts.Changelog.Name)
+      artifactName: $(artifactsName_ChangeLog)
       downloadPath: $(Build.ArtifactStagingDirectory)
 
   # Create GitHub release
@@ -305,8 +305,8 @@ jobs:
       tag: v$(NBGV_NuGetPackageVersion)
       title: v$(NBGV_NuGetPackageVersion)
       releaseNotesSource: file
-      releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(Artifacts.Changelog.Name)/changelog.md
-      assets: $(Build.ArtifactStagingDirectory)/$(Artifacts.Binaries.Name)/*.nupkg
+      releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(artifactsName_ChangeLog)/changelog.md
+      assets: $(Build.ArtifactStagingDirectory)/$(artifactsName_Binaries)/*.nupkg
       addChangeLog: false
 
 # Job to create a GitHub *DRAFT* release (only if a package was uploaded to myget.org)
@@ -341,11 +341,11 @@ jobs:
 
   # Get artifacts (changelog)
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifacts: $(Artifacts.Changelog.Name)'
+    displayName: 'Download Artifacts: $(artifactsName_ChangeLog)'
     inputs:
       buildType: current
       downloadType: single
-      artifactName: $(Artifacts.Changelog.Name)
+      artifactName: $(artifactsName_ChangeLog)
       downloadPath: $(Build.ArtifactStagingDirectory)
 
   # Create GitHub *DRAFT* release
@@ -360,7 +360,7 @@ jobs:
       tag: vNext
       title: v$(NBGV_NuGetPackageVersion)
       releaseNotesSource: file
-      releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(Artifacts.Changelog.Name)/changelog.md
+      releaseNotesFile: $(Build.ArtifactStagingDirectory)/$(artifactsName_ChangeLog)/changelog.md
       addChangeLog: false
       isDraft: true
 
@@ -387,7 +387,7 @@ jobs:
 
   - powershell : |
       # Load variables JSON file generated during build      
-      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/$(Artifacts.Variables.Name)/nbgv.json" | ConvertFrom-Json
+      $json = Get-Content -Raw "$(Build.ArtifactStagingDirectory)/$(artifactsName_Variables)/nbgv.json" | ConvertFrom-Json
 
       # for each variable, set the value as Azure Pipelines variable
       $variableNames = $json | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name


### PR DESCRIPTION
The post-build Azure Pipelines jobs (like creating a GitHub release or uploading the package to MyGet or NuGet.org) require information about the version being built. 
Because versioning is done through Nerdbank.GitVersioning, these jobs used to run the `nbgv` tool to determine the version.
However, to run the tool, the jobs had to check out the sources, install a .NET Core SDK and download the tool from NuGet.

With this change, the build job publishes the version information as an build artifact and the post-build jobs can get all required versioning information without installing .NET Core or running `nbgv`. This should reduce the jobs'  runtime from 1.5 minutes to 10-20 seconds.

Because the program sources are not required for any of the jobs except for the Build job, the checkout is now deactivated for all of these jobs.