### PR TITLE
feat: Allow overriding settings for individual footers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,8 @@ For example setting `key:subkey` to `value` would need to be specified in the co
 ## Settings List
 
 - [Scopes](./configuration/settings/scopes.md)
-- [Footers](./configuration/settings/footers.md)
+- [Footer Settings](./configuration/settings/footers.md)
+  - [Footer Display Name](./configuration/settings/footers.md#footer-display-name)
 - [Entry Types](./configuration/settings/entry-types.md)
 - [Filter](./configuration/settings/filter.md)
 - [Parser Mode](./configuration/settings/parser-mode.md)

--- a/docs/configuration/settings/entry-types.md
+++ b/docs/configuration/settings/entry-types.md
@@ -55,7 +55,6 @@ In the default configuration, the following display names are pre-configured:
 | `feat`     | New Features |
 | `fix`      | Bug Fixes    |
 
-
 ---
 
 ⚠️ Using this setting in a configuration file will overwrite the default value.

--- a/docs/configuration/settings/footers.md
+++ b/docs/configuration/settings/footers.md
@@ -1,13 +1,23 @@
-# Footers Setting
+# Footer Settings
+
+---
+
+⚠️ The format of the "Footers" setting has changed in version 0.3 of changelog.
+
+For documentation on the "Footers" setting in version 0.2, see [Footers Setting (v0.2)](https://github.com/ap0llo/changelog/blob/release/v0.2/docs/configuration.md#footers).
+
+---
+
+## Footer Display Name
 
 <table>
     <tr>
         <td><b>Setting</b></td>
-        <td><code>changelog:footers</code></td>
+        <td><code>changelog:footers:&lt;FOOTERNAME&gt;:displayname</code></td>
     </tr>
     <tr>
         <td><b>Environment Variable</b></td>
-        <td>-</td>
+        <td><code>CHANGELOG__FOOTERS__&lt;FOOTERNAME&gt;__DISPLAYNAME</code></td>
     </tr>
     <tr>
         <td><b>Commandline Parameter</b></td>
@@ -19,23 +29,26 @@
     </tr>
     <tr>
         <td><b>Version Support</b></td>
-        <td>0.1+</td>
+        <td>0.3+</td>
     </tr>
 </table>
 
-The *Footers* setting configures how [Conventional Commit](https://www.conventionalcommits.org/) footers are displayed.
+
+The *Footer Dispaly Name* setting configures how [Conventional Commit](https://www.conventionalcommits.org/) footers are displayed.
+
 By default, footers are included unchanged in the output.
-Using this setting, you can configure a footer's display name.
-When a display name is configured, it will be used in the output instead of the footer's name.
+Using this setting, you can configure a footer's display name which will be used in the output instead of the footer's name.
 
 ## Example
+
+The example below shows how to configure a display name for the `See-Also` footer.
 
 ```json
 {
     "changelog" : {
-        "footers" : [
-            { "name":  "see-also", "displayName":  "See Also" }
-        ]
+        "footers" : {
+            "see-also": {  "displayName":  "See Also" }
+        }
     }
 }
 ```
@@ -43,3 +56,4 @@ When a display name is configured, it will be used in the output instead of the 
 ## See Also
 
 - [Configuration Overview](../../configuration.md)
+- [Conventional Commits](https://www.conventionalcommits.org/)

--- a/schemas/configuration/schema.json
+++ b/schemas/configuration/schema.json
@@ -43,12 +43,14 @@
                     "description": "Specifies the output path for the generated change log."
                 },
                 "footers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/footerConfiguration"
+                    "type": "object",
+                    "patternProperties": {
+                        ".*" : {
+                            "$ref": "#/definitions/footerConfiguration"
+                        }
                     },
                     "title": "Footers",
-                    "description": "Sets preferences on how  Conventional Commit footers are processed."
+                    "description": "Sets preferences on how Conventional Commit footers are processed."
                 },
                 "integrations": {
                     "$ref": "#/definitions/integrationsConfiguration",
@@ -125,10 +127,6 @@
         "footerConfiguration": {
             "type": "object",
             "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Specifies the name of the footer the settings apply to."
-                },
                 "displayName": {
                     "type": "string",
                     "description": "Specifies the display name of the footer. When no display name is configured, the footer's name is used as display name."

--- a/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
+++ b/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
@@ -393,7 +393,7 @@ namespace Grynwald.ChangeLog.Test.Configuration
             yield return TestCase("versionRange", config => config.VersionRange, "[1.2.3,)");
 
             //
-            // Outout Path setting
+            // Output Path setting
             //
             yield return TestCase("outputPath", config => config.OutputPath, "outputPath1");
 

--- a/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
+++ b/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Grynwald.ChangeLog.Configuration;
 using Grynwald.ChangeLog.Test.ConventionalCommits;
 using Xunit;
@@ -59,14 +60,13 @@ namespace Grynwald.ChangeLog.Test.Configuration
         [InlineData("")]
         [InlineData("\t")]
         [InlineData("  ")]
-        [InlineData(null)]
-        public void Footer_name_must_not_be_null_of_whitespace(string footerName)
+        public void Footer_name_must_not_be_empty_or_whitespace(string footerName)
         {
             // ARRANGE
             var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
-            config.Footers = new[]
+            config.Footers = new Dictionary<string, ChangeLogConfiguration.FooterConfiguration>()
             {
-                new ChangeLogConfiguration.FooterConfiguration(){ Name = footerName, DisplayName = "Display Name"}
+                { footerName, new ChangeLogConfiguration.FooterConfiguration() { DisplayName = "Display Name"} }
             };
 
             var sut = new ConfigurationValidator();

--- a/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
+++ b/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
@@ -36,7 +36,7 @@ namespace Grynwald.ChangeLog.Test.Configuration
         [InlineData("\t")]
         [InlineData("  ")]
         [InlineData(null)]
-        public void Scope_name_must_not_be_null_of_whitespace(string scopeName)
+        public void Scope_name_must_not_be_null_or_whitespace(string scopeName)
         {
             // ARRANGE
             var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
@@ -163,7 +163,7 @@ namespace Grynwald.ChangeLog.Test.Configuration
         [InlineData("\t")]
         [InlineData("  ")]
         [InlineData(null)]
-        public void Entry_type_must_not_be_null_of_whitespace(string entryType)
+        public void Entry_type_must_not_be_null_or_whitespace(string entryType)
         {
             // ARRANGE
             var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();

--- a/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
+++ b/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
@@ -81,6 +81,29 @@ namespace Grynwald.ChangeLog.Test.Configuration
         }
 
         [Theory]
+        [InlineData("some-footer")]
+        public void Footer_name_must_be_unique(string footerName)
+        {
+            // ARRANGE
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            config.Footers = new Dictionary<string, ChangeLogConfiguration.FooterConfiguration>()
+            {
+                { footerName.ToLower(), new ChangeLogConfiguration.FooterConfiguration() },
+                { footerName.ToUpper(), new ChangeLogConfiguration.FooterConfiguration() }
+            };
+
+            var sut = new ConfigurationValidator();
+
+            // ACT 
+            var result = sut.Validate(config);
+
+            // ASSERT
+            Assert.False(result.IsValid);
+            var error = Assert.Single(result.Errors);
+            Assert.Contains("'Footer Name' must be unique", error.ErrorMessage);
+        }
+
+        [Theory]
         [InlineData("")]
         [InlineData(null)]
         public void VersionRange_can_be_null_or_empty(string versionRange)

--- a/src/ChangeLog.Test/Templates/ModelExtensionsTest.cs
+++ b/src/ChangeLog.Test/Templates/ModelExtensionsTest.cs
@@ -1,4 +1,5 @@
-﻿using Grynwald.ChangeLog.Configuration;
+﻿using System.Collections.Generic;
+using Grynwald.ChangeLog.Configuration;
 using Grynwald.ChangeLog.ConventionalCommits;
 using Grynwald.ChangeLog.Model;
 using Grynwald.ChangeLog.Templates;
@@ -103,9 +104,9 @@ namespace Grynwald.ChangeLog.Test.Templates
             // ARRANGE
             var configuration = new ChangeLogConfiguration()
             {
-                Footers = new[]
+                Footers = new Dictionary<string, ChangeLogConfiguration.FooterConfiguration>()
                 {
-                    new ChangeLogConfiguration.FooterConfiguration() { Name = configuredFooter, DisplayName = "Footer Display Name" }
+                    { configuredFooter, new ChangeLogConfiguration.FooterConfiguration() { DisplayName = "Footer Display Name" } }
                 }
             };
 
@@ -126,9 +127,9 @@ namespace Grynwald.ChangeLog.Test.Templates
             var footerName = "footerName";
             var configuration = new ChangeLogConfiguration()
             {
-                Footers = new[]
+                Footers = new Dictionary<string, ChangeLogConfiguration.FooterConfiguration>()
                 {
-                    new ChangeLogConfiguration.FooterConfiguration() { Name = "someOtherFooter", DisplayName = "Footer Display Name" }
+                    { "someOtherFooter",  new ChangeLogConfiguration.FooterConfiguration() { DisplayName = "Footer Display Name" } }
                 }
             };
 
@@ -152,9 +153,9 @@ namespace Grynwald.ChangeLog.Test.Templates
             var footerName = "footerName";
             var configuration = new ChangeLogConfiguration()
             {
-                Footers = new[]
+                Footers = new Dictionary<string, ChangeLogConfiguration.FooterConfiguration>()
                 {
-                    new ChangeLogConfiguration.FooterConfiguration() { Name = footerName, DisplayName = configuredDisplayName }
+                    { footerName, new ChangeLogConfiguration.FooterConfiguration() { DisplayName = configuredDisplayName } }
                 }
             };
 

--- a/src/ChangeLog.Test/Templates/TemplateTest.cs
+++ b/src/ChangeLog.Test/Templates/TemplateTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using ApprovalTests;
 using ApprovalTests.Reporters;
@@ -398,10 +399,10 @@ namespace Grynwald.ChangeLog.Test.Templates
             // the output must use the display name instead of the footer name
 
             var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
-            config.Footers = new[]
+            config.Footers = new Dictionary<string, ChangeLogConfiguration.FooterConfiguration>
             {
-                new ChangeLogConfiguration.FooterConfiguration() { Name = "see-also", DisplayName = "See Also" },
-                new ChangeLogConfiguration.FooterConfiguration() { Name = "reviewed-by", DisplayName = "Reviewed by" }
+                { "see-also", new ChangeLogConfiguration.FooterConfiguration() { DisplayName = "See Also" } },
+                {  "reviewed-by", new ChangeLogConfiguration.FooterConfiguration() { DisplayName = "Reviewed by" } }
             };
 
             var versionChangeLog = GetSingleVersionChangeLog(

--- a/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
+++ b/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Grynwald.ChangeLog.Validation;
 
@@ -16,9 +17,6 @@ namespace Grynwald.ChangeLog.Configuration
 
         public class FooterConfiguration
         {
-            [ValidationDisplayName("Footer Name")]
-            public string? Name { get; set; }
-
             public string? DisplayName { get; set; }
         }
 
@@ -144,7 +142,7 @@ namespace Grynwald.ChangeLog.Configuration
 
         public string RepositoryPath { get; set; } = null!;
 
-        public FooterConfiguration[] Footers { get; set; } = Array.Empty<FooterConfiguration>();
+        public Dictionary<string, FooterConfiguration> Footers { get; set; } = new Dictionary<string, FooterConfiguration>();
 
         public IntegrationsConfiguration Integrations { get; set; } = new IntegrationsConfiguration();
 

--- a/src/ChangeLog/Configuration/ChangeLogConfigurationLoader.cs
+++ b/src/ChangeLog/Configuration/ChangeLogConfigurationLoader.cs
@@ -3,6 +3,8 @@ using System.Reflection;
 using System.Text;
 using Grynwald.Utilities.Configuration;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Grynwald.ChangeLog.Configuration
 {
@@ -13,12 +15,14 @@ namespace Grynwald.ChangeLog.Configuration
             using var defaultSettingsStream = GetDefaultSettingsStream();
             using var configurationFileStream = GetFileStreamOrEmpty(configurationFilePath);
 
+            using var preparedStream = PrepareConfigurationFileStream(configurationFileStream);
+
             return new ConfigurationBuilder()
                 .AddJsonStream(defaultSettingsStream)
                 // Use AddJsonStream() because AddJsonFile() assumes the file name
                 // is relative to the ConfigurationBuilder's base directory and does not seem to properly
                 // handle absolute paths
-                .AddJsonStream(configurationFileStream)
+                .AddJsonStream(preparedStream)
                 .AddEnvironmentVariables()
                 .AddObject(settingsObject)
                 .Load();
@@ -54,6 +58,75 @@ namespace Grynwald.ChangeLog.Configuration
                 .Bind(configuration);
 
             return configuration;
+        }
+
+        /// <summary>
+        /// Prepares the configuration file stream for processing by the configuration binder.
+        /// </summary>
+        /// <remarks>
+        /// Performs required adjustments to the JSON file in case the file does not follow the currently expected file structure
+        /// but is a configuration file intended for earlier versions of changelog.
+        /// </remarks>
+        private static Stream PrepareConfigurationFileStream(Stream configFileStream)
+        {
+            var json = ReadJsonFromStream(configFileStream);
+
+            if (json is JObject jobject && jobject.Property("changelog")?.Value is JObject changelogSetingsObject)
+            {
+                // Before version 0.3, the "footers" property was a JSON array.
+                // In version 0.3 the array was replaced by a JSON object in the configuration file
+                // To avoid unexpected behavior when loading a "old" configuration file
+                // (Microsoft.Extensions.Configuration will try to bind the array to the dictionary v0.3+ uses)
+                // remove the array from the JSON if it is present.
+                var footersProperty = changelogSetingsObject?.Property("footers");
+                if (footersProperty != null && footersProperty.Value.Type == JTokenType.Array)
+                {
+                    footersProperty.Remove();
+                }
+            }
+
+            return SaveJsonToStream(json);
+        }
+
+        /// <summary>
+        /// Reads the specified Stream as JSON
+        /// </summary>
+        private static JToken ReadJsonFromStream(Stream stream)
+        {
+            using var streamReader = new StreamReader(stream);
+            using var reader = new JsonTextReader(streamReader);
+
+            var json = JToken.ReadFrom(reader);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Writes the specified JSON to a MemoryStream.
+        /// </summary>
+        private static Stream SaveJsonToStream(JToken json)
+        {
+            var outputStream = new MemoryStream();
+
+#if NETCOREAPP2_1
+            // On .NET Core 2.1, a encoding and buffer size MUST be required.
+            // UTF-8 without BOM and 1024 are the default values used by StreamWriter
+            // (see https://source.dot.net/#System.Private.CoreLib/StreamWriter.cs,74)
+            var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+            using (var streamWriter = new StreamWriter(outputStream, encoding, 1024, leaveOpen: true))
+#else
+            // On .NET Core 3.1 (and presumably later), we can just set encoding and buffer size to null/-1
+            // and StreamWriter will use the default values without the need to hard-code them here.
+            using (var streamWriter = new StreamWriter(outputStream, null, -1, leaveOpen: true))
+#endif
+            using (var writer = new JsonTextWriter(streamWriter))
+            {
+                json.WriteTo(writer);
+            }
+
+            // Reset Memory-Stream to make it readable
+            outputStream.Seek(0, SeekOrigin.Begin);
+            return outputStream;
         }
     }
 }

--- a/src/ChangeLog/Configuration/ConfigurationValidator.cs
+++ b/src/ChangeLog/Configuration/ConfigurationValidator.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
+using Grynwald.ChangeLog.ConventionalCommits;
 using Grynwald.ChangeLog.Validation;
 
 namespace Grynwald.ChangeLog.Configuration
@@ -18,7 +20,15 @@ namespace Grynwald.ChangeLog.Configuration
                 .ChildRules(scope => scope.RuleFor(x => x.Name).NotEmpty());
 
             RuleForEach(x => x.Footers)
-                .ChildRules(footer => footer.RuleFor(x => x.Key).NotEmpty().WithName("Footer Name"));
+                .ChildRules(footer => footer.RuleFor(x => x.Key).NotEmpty().WithName("Footer Name"))
+                .DependentRules(() =>
+                    RuleFor(x => x.Footers.Keys)
+                       .Must(keys =>
+                       {
+                           var footerNames = keys.Select(key => new CommitMessageFooterName(key));
+                           return footerNames.Distinct().Count() == keys.Count;
+                       })
+                       .WithMessage("'Footer Name' must be unique"));
 
             RuleForEach(x => x.EntryTypes)
                 .ChildRules(entryType => entryType.RuleFor(x => x.Type).NotEmpty());

--- a/src/ChangeLog/Configuration/ConfigurationValidator.cs
+++ b/src/ChangeLog/Configuration/ConfigurationValidator.cs
@@ -18,7 +18,7 @@ namespace Grynwald.ChangeLog.Configuration
                 .ChildRules(scope => scope.RuleFor(x => x.Name).NotEmpty());
 
             RuleForEach(x => x.Footers)
-                .ChildRules(footer => footer.RuleFor(x => x.Name).NotEmpty());
+                .ChildRules(footer => footer.RuleFor(x => x.Key).NotEmpty().WithName("Footer Name"));
 
             RuleForEach(x => x.EntryTypes)
                 .ChildRules(entryType => entryType.RuleFor(x => x.Type).NotEmpty());

--- a/src/ChangeLog/Configuration/defaultSettings.json
+++ b/src/ChangeLog/Configuration/defaultSettings.json
@@ -15,7 +15,7 @@
 
     "scopes": [],
 
-    "footers": [],
+    "footers": {},
 
     "filter": {
       "include": [

--- a/src/ChangeLog/Templates/ModelExtensions.cs
+++ b/src/ChangeLog/Templates/ModelExtensions.cs
@@ -37,10 +37,10 @@ namespace Grynwald.ChangeLog.Templates
         public static string GetFooterDisplayName(this ChangeLogEntryFooter footer, ChangeLogConfiguration configuration)
         {
             var displayName = configuration.Footers
-                .FirstOrDefault(c =>
-                    !String.IsNullOrWhiteSpace(c.Name) &&
-                    new CommitMessageFooterName(c.Name).Equals(footer.Name)
-                )?.DisplayName;
+                .FirstOrDefault(kvp =>
+                    !String.IsNullOrWhiteSpace(kvp.Key) &&
+                    new CommitMessageFooterName(kvp.Key).Equals(footer.Name)
+                ).Value?.DisplayName;
 
             return !String.IsNullOrWhiteSpace(displayName) ? displayName : footer.Name.Value;
         }


### PR DESCRIPTION
Change configuration file format to allow overriding of settings for individual footers without having to repeat values specified in the default settings.

This changes the `footer` setting in the configuration file from a JSON array to a JSON object. The settings for a specific footer are modeled as a property on the JSON object named like the footer the settings apply to.
This allows overriding the settings for a specified footer based on its name rather than its position in the list (when specifying footer settings as environment variables).

💥 BREAKING CHANGE: Changes the configuration file format for footers. Configuration files will intended for v0.2 need to be updated to the new format manually.

- [x] Adjust configuration format to allow overriding of settings for individual footers
- [x] Additional validation of footer settings
- [x] Check what happens if a v0.2 config file is loaded
- [x] Update docs
