### PR TITLE
feat: Allow overriding individual scope display names

### DIFF
--- a/changelog.settings.json
+++ b/changelog.settings.json
@@ -1,7 +1,7 @@
 {
     "$schema": "./schemas/configuration/schema.json",
     "changelog": {
-    
+
         "integrations": {
             "provider": "GitHub"
         },
@@ -11,6 +11,6 @@
             "gitlab" :  { "displayName": "GitLab Integration" },
             "templates" : { "displayName": "Templates" },
             "parser" : { "displayName" : "Commit Message Parser" }
-        }    
+        }
     }
 }

--- a/changelog.settings.json
+++ b/changelog.settings.json
@@ -6,24 +6,11 @@
             "provider": "GitHub"
         },
 
-        "scopes": [
-            {
-                "name": "github",
-                "displayName": "GitHub Integration"
-            },
-            {
-                "name": "gitlab",
-                "displayName": "GitLab Integration"
-            },
-            {
-                "name": "templates",
-                "displayName": "Templates"
-            },
-            {
-                "name": "parser",
-                "displayName" : "Commit Message Parser"
-            }
-        ]
-
+        "scopes": {
+            "github" : { "displayName": "GitHub Integration" },
+            "gitlab" :  { "displayName": "GitLab Integration" },
+            "templates" : { "displayName": "Templates" },
+            "parser" : { "displayName" : "Commit Message Parser" }
+        }    
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,8 @@ For example setting `key:subkey` to `value` would need to be specified in the co
 
 ## Settings List
 
-- [Scopes](./configuration/settings/scopes.md)
+- [Scope Settings](./configuration/settings/scopes.md)
+  - [Scope Display Name](./configuration/settings/scopes.md#scope-display-name)
 - [Footer Settings](./configuration/settings/footers.md)
   - [Footer Display Name](./configuration/settings/footers.md#footer-display-name)
 - [Entry Types](./configuration/settings/entry-types.md)

--- a/docs/configuration/settings/footers.md
+++ b/docs/configuration/settings/footers.md
@@ -33,8 +33,7 @@ For documentation on the "Footers" setting in version 0.2, see [Footers Setting 
     </tr>
 </table>
 
-
-The *Footer Dispaly Name* setting configures how [Conventional Commit](https://www.conventionalcommits.org/) footers are displayed.
+The *Footer Display Name* setting configures how [Conventional Commit](https://www.conventionalcommits.org/) footers are displayed.
 
 By default, footers are included unchanged in the output.
 Using this setting, you can configure a footer's display name which will be used in the output instead of the footer's name.

--- a/docs/configuration/settings/scopes.md
+++ b/docs/configuration/settings/scopes.md
@@ -1,13 +1,23 @@
-# Scopes Setting
+# Scope Settings
+
+---
+
+⚠️ The format of the "Scopes" setting has changed in version 0.3 of changelog.
+
+For documentation on the "Scopes" setting in version 0.2, see [Scopes Setting (v0.2)](https://github.com/ap0llo/changelog/blob/release/v0.2/docs/configuration.md#scopes).
+
+---
+
+## Scope Display Name
 
 <table>
     <tr>
         <td><b>Setting</b></td>
-        <td><code>changelog:scopes</code></td>
+        <td><code>changelog:scopes&lt;SCOPENAME&gt;:displayname</code></td>
     </tr>
     <tr>
         <td><b>Environment Variable</b></td>
-        <td>-</td>
+        <td><code>CHANGELOG__SCOPES__&lt;SCOPENAME&gt;__DISPLAYNAME</code></td>
     </tr>
     <tr>
         <td><b>Commandline Parameter</b></td>
@@ -15,27 +25,31 @@
     </tr>
     <tr>
         <td><b>Default value</b></td>
-        <td><em>Empty</em></td>
+        <td><code>{ }</code></td>
     </tr>
     <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
+        <td><b>Version Support</b></td> 
+        <td>0.3+</td>
     </tr>
 </table>
 
+The *Scope Display Name* setting configures how [Conventional Commit](https://www.conventionalcommits.org/) scopes are displayed.
+
 The *Scopes* setting configures how [Conventional Commit](https://www.conventionalcommits.org/) scopes are displayed.
+
 By default, the scopes are included unchanged in the output.
-Using this setting, you can configure a scope's display name.
-When a display name is configured, it will be used in the output instead of the scope's name.
+Using this setting, you can configure a scope's display name which will be used in the output instead of the scope's name.
 
 ## Example
+
+To set the display name for the `myScope` scope, in the configuration file, use
 
 ```json
 {
     "changelog" : {
-        "scopes" : [
-            { "name":  "myScope", "displayName":  "Scope Display Name" }
-        ]
+        "scopes" : {
+            "myScope" : { "displayName":  "Scope Display Name" }
+        }
     }
 }
 ```

--- a/schemas/configuration/schema.json
+++ b/schemas/configuration/schema.json
@@ -17,9 +17,11 @@
             "type": "object",
             "properties": {
                 "scopes": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/scopeConfiguration"
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {
+                            "$ref": "#/definitions/scopeConfiguration"
+                        }
                     },
                     "title": "Scopes",
                     "description": "Sets preferences on how  Conventional Commit scopes are processed."
@@ -154,10 +156,6 @@
         "scopeConfiguration": {
             "type": "object",
             "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Specifies the name of the scope the settings apply to."
-                },
                 "displayName": {
                     "type": [
                         "string",

--- a/schemas/configuration/schema.json
+++ b/schemas/configuration/schema.json
@@ -23,6 +23,7 @@
                             "$ref": "#/definitions/scopeConfiguration"
                         }
                     },
+                    "default" : { },
                     "title": "Scopes",
                     "description": "Sets preferences on how  Conventional Commit scopes are processed."
                 },

--- a/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
+++ b/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
@@ -743,5 +743,31 @@ namespace Grynwald.ChangeLog.Test.Configuration
             Assert.DoesNotContain("some-footer", config.Footers.Keys);
         }
 
+        [Fact]
+        public void GetConfiguration_ignores_scope_configuration_if_value_is_array()
+        {
+            // ARRANGE
+
+            // Before v0.3, the "scopes" property was expected to be a array of configuration objects, but
+            // was changed to a object (de-serialized into a dictionary).
+            // There is no migration for configuration files intended for earlier versions.
+            // Configuration values that are not in the expected format must be ignored.
+
+            var json = @"{
+                ""changelog"" : {
+                    ""scopes"" : [
+                        { ""name"":  ""some-footer"", ""displayName"":  ""Some Display Name"" }
+                    ]
+                }
+            }";
+            File.WriteAllText(m_ConfigurationFilePath, json);
+
+            // ACT 
+            var config = ChangeLogConfigurationLoader.GetConfiguration(m_ConfigurationFilePath);
+
+            // ASSERT
+            Assert.NotNull(config.Scopes);
+            Assert.Empty(config.Scopes);
+        }
     }
 }

--- a/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
+++ b/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
@@ -515,24 +515,24 @@ namespace Grynwald.ChangeLog.Test.Configuration
             yield return TestCase(
                 key: "scopes",
                 getter: config => config.Scopes,
-                value: new[]
+                value: new Dictionary<string, ChangeLogConfiguration.ScopeConfiguration>()
                 {
-                    new ChangeLogConfiguration.ScopeConfiguration() { Name = "scope1", DisplayName = "Display Name 1" },
-                    new ChangeLogConfiguration.ScopeConfiguration() { Name = "scope2", DisplayName = "Display Name 2" }
+                    { "scope1", new ChangeLogConfiguration.ScopeConfiguration() { DisplayName = "Display Name 1" } },
+                    { "scope2", new ChangeLogConfiguration.ScopeConfiguration() { DisplayName = "Display Name 2" } }
                 },
                 target: SettingsTarget.ConfigurationFile,
                 assert: config =>
                 {
                     Assert.Collection(config.Scopes,
-                      s =>
+                      kvp =>
                       {
-                          Assert.Equal("scope1", s.Name);
-                          Assert.Equal("Display Name 1", s.DisplayName);
+                          Assert.Equal("scope1", kvp.Key);
+                          Assert.Equal("Display Name 1", kvp.Value.DisplayName);
                       },
-                      s =>
+                      kvp =>
                       {
-                          Assert.Equal("scope2", s.Name);
-                          Assert.Equal("Display Name 2", s.DisplayName);
+                          Assert.Equal("scope2", kvp.Key);
+                          Assert.Equal("Display Name 2", kvp.Value.DisplayName);
                       });
                 });
 

--- a/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
+++ b/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
@@ -55,7 +55,7 @@ namespace Grynwald.ChangeLog.Test.Configuration
         }
 
         [Theory]
-        [InlineData("some-footer")]
+        [InlineData("some-scope")]
         public void Scope_name_must_be_unique(string scopeName)
         {
             // ARRANGE

--- a/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
+++ b/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Grynwald.ChangeLog.Configuration;
-using Grynwald.ChangeLog.Test.ConventionalCommits;
 using Xunit;
 
 namespace Grynwald.ChangeLog.Test.Configuration
@@ -54,6 +53,30 @@ namespace Grynwald.ChangeLog.Test.Configuration
             var error = Assert.Single(result.Errors);
             Assert.Contains("'Scope Name'", error.ErrorMessage);
         }
+
+        [Theory]
+        [InlineData("some-footer")]
+        public void Scope_name_must_be_unique(string scopeName)
+        {
+            // ARRANGE
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            config.Scopes = new Dictionary<string, ChangeLogConfiguration.ScopeConfiguration>()
+            {
+                { scopeName.ToLower(), new ChangeLogConfiguration.ScopeConfiguration() },
+                { scopeName.ToUpper(), new ChangeLogConfiguration.ScopeConfiguration() }
+            };
+
+            var sut = new ConfigurationValidator();
+
+            // ACT 
+            var result = sut.Validate(config);
+
+            // ASSERT
+            Assert.False(result.IsValid);
+            var error = Assert.Single(result.Errors);
+            Assert.Contains("'Scope Name' must be unique", error.ErrorMessage);
+        }
+
 
         [Theory]
         [InlineData("")]

--- a/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
+++ b/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
@@ -35,14 +35,13 @@ namespace Grynwald.ChangeLog.Test.Configuration
         [InlineData("")]
         [InlineData("\t")]
         [InlineData("  ")]
-        [InlineData(null)]
-        public void Scope_name_must_not_be_null_or_whitespace(string scopeName)
+        public void Scope_name_must_not_be_empty_or_whitespace(string scopeName)
         {
             // ARRANGE
             var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
-            config.Scopes = new[]
+            config.Scopes = new Dictionary<string, ChangeLogConfiguration.ScopeConfiguration>()
             {
-                new ChangeLogConfiguration.ScopeConfiguration(){ Name = scopeName, DisplayName = "Display Name"}
+                { scopeName, new ChangeLogConfiguration.ScopeConfiguration(){ DisplayName = "Display Name"} }
             };
 
             var sut = new ConfigurationValidator();

--- a/src/ChangeLog.Test/Templates/ModelExtensionsTest.cs
+++ b/src/ChangeLog.Test/Templates/ModelExtensionsTest.cs
@@ -36,9 +36,9 @@ namespace Grynwald.ChangeLog.Test.Templates
             // ARRANGE
             var config = new ChangeLogConfiguration()
             {
-                Scopes = new[]
+                Scopes = new Dictionary<string, ChangeLogConfiguration.ScopeConfiguration>()
                 {
-                    new ChangeLogConfiguration.ScopeConfiguration() { Name = configuredScope, DisplayName = "Scope Display Name" }
+                    { configuredScope, new ChangeLogConfiguration.ScopeConfiguration() { DisplayName = "Scope Display Name" } }
                 }
             };
             var changeLogEntry = GetChangeLogEntry(scope: scope);
@@ -60,9 +60,9 @@ namespace Grynwald.ChangeLog.Test.Templates
             // ARRANGE
             var config = new ChangeLogConfiguration()
             {
-                Scopes = new[]
+                Scopes = new Dictionary<string, ChangeLogConfiguration.ScopeConfiguration>()
                 {
-                    new ChangeLogConfiguration.ScopeConfiguration() { Name = "someScope", DisplayName = displayName }
+                    { "someScope",  new ChangeLogConfiguration.ScopeConfiguration() { DisplayName = displayName } }
                 }
             };
             var changeLogEntry = GetChangeLogEntry(scope: "someScope");
@@ -80,9 +80,9 @@ namespace Grynwald.ChangeLog.Test.Templates
             // ARRANGE
             var config = new ChangeLogConfiguration()
             {
-                Scopes = new[]
+                Scopes = new Dictionary<string, ChangeLogConfiguration.ScopeConfiguration>()
                 {
-                    new ChangeLogConfiguration.ScopeConfiguration() { Name = "someScope", DisplayName = "Scope Display Name" }
+                    { "someScope",  new ChangeLogConfiguration.ScopeConfiguration() { DisplayName = "Scope Display Name" } }
                 }
             };
             var changeLogEntry = GetChangeLogEntry(scope: "someScopeOther");

--- a/src/ChangeLog.Test/Templates/TemplateTest.cs
+++ b/src/ChangeLog.Test/Templates/TemplateTest.cs
@@ -347,9 +347,9 @@ namespace Grynwald.ChangeLog.Test.Templates
             // it must be used in the output instead of the actual scope
 
             var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
-            config.Scopes = new[]
+            config.Scopes = new Dictionary<string, ChangeLogConfiguration.ScopeConfiguration>()
             {
-                new ChangeLogConfiguration.ScopeConfiguration() { Name = "scope1", DisplayName = "Scope 1 Display Name" }
+                { "scope1", new ChangeLogConfiguration.ScopeConfiguration() { DisplayName = "Scope 1 Display Name" } }
             };
 
 

--- a/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
+++ b/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
@@ -9,9 +9,6 @@ namespace Grynwald.ChangeLog.Configuration
     {
         public class ScopeConfiguration
         {
-            [ValidationDisplayName("Scope Name")]
-            public string Name { get; set; } = "";
-
             public string? DisplayName { get; set; }
         }
 
@@ -134,7 +131,7 @@ namespace Grynwald.ChangeLog.Configuration
         }
 
 
-        public ScopeConfiguration[] Scopes { get; set; } = Array.Empty<ScopeConfiguration>();
+        public Dictionary<string, ScopeConfiguration> Scopes { get; set; } = new Dictionary<string, ScopeConfiguration>();
 
         public string[] TagPatterns { get; set; } = Array.Empty<string>();
 

--- a/src/ChangeLog/Configuration/ChangeLogConfigurationLoader.cs
+++ b/src/ChangeLog/Configuration/ChangeLogConfigurationLoader.cs
@@ -83,6 +83,17 @@ namespace Grynwald.ChangeLog.Configuration
                 {
                     footersProperty.Remove();
                 }
+
+                // Before version 0.3, the "scopes" property was a JSON array.
+                // In version 0.3 the array was replaced by a JSON object in the configuration file
+                // To avoid unexpected behavior when loading a "old" configuration file
+                // (Microsoft.Extensions.Configuration will try to bind the array to the dictionary v0.3+ uses)
+                // remove the array from the JSON if it is present.
+                var scopesProperty = changelogSetingsObject?.Property("scopes");
+                if (scopesProperty != null && scopesProperty.Value.Type == JTokenType.Array)
+                {
+                    scopesProperty.Remove();
+                }
             }
 
             return SaveJsonToStream(json);

--- a/src/ChangeLog/Configuration/ConfigurationValidator.cs
+++ b/src/ChangeLog/Configuration/ConfigurationValidator.cs
@@ -17,7 +17,11 @@ namespace Grynwald.ChangeLog.Configuration
             ValidatorOptions.Global.UseCustomDisplayNameResolver();
 
             RuleForEach(x => x.Scopes)
-                .ChildRules(scope => scope.RuleFor(x => x.Key).NotEmpty().WithName("Scope Name"));
+                .ChildRules(scope => scope.RuleFor(x => x.Key).NotEmpty().WithName("Scope Name"))
+                .DependentRules(() =>
+                    RuleFor(x => x.Scopes.Keys)
+                       .Must(keys => keys.Distinct(StringComparer.OrdinalIgnoreCase).Count() == keys.Count)
+                       .WithMessage("'Scope Name' must be unique"));
 
             RuleForEach(x => x.Footers)
                 .ChildRules(footer => footer.RuleFor(x => x.Key).NotEmpty().WithName("Footer Name"))

--- a/src/ChangeLog/Configuration/ConfigurationValidator.cs
+++ b/src/ChangeLog/Configuration/ConfigurationValidator.cs
@@ -17,7 +17,7 @@ namespace Grynwald.ChangeLog.Configuration
             ValidatorOptions.Global.UseCustomDisplayNameResolver();
 
             RuleForEach(x => x.Scopes)
-                .ChildRules(scope => scope.RuleFor(x => x.Name).NotEmpty());
+                .ChildRules(scope => scope.RuleFor(x => x.Key).NotEmpty().WithName("Scope Name"));
 
             RuleForEach(x => x.Footers)
                 .ChildRules(footer => footer.RuleFor(x => x.Key).NotEmpty().WithName("Footer Name"))

--- a/src/ChangeLog/Configuration/defaultSettings.json
+++ b/src/ChangeLog/Configuration/defaultSettings.json
@@ -13,7 +13,7 @@
       }
     ],
 
-    "scopes": [],
+    "scopes": { },
 
     "footers": {
       "see-also" : { "displayName": "See Also" },

--- a/src/ChangeLog/Templates/ModelExtensions.cs
+++ b/src/ChangeLog/Templates/ModelExtensions.cs
@@ -22,7 +22,7 @@ namespace Grynwald.ChangeLog.Templates
             if (String.IsNullOrEmpty(entry.Scope))
                 return null;
 
-            var displayName = configuration.Scopes.FirstOrDefault(scope => StringComparer.OrdinalIgnoreCase.Equals(scope.Name, entry.Scope))?.DisplayName;
+            var displayName = configuration.Scopes.FirstOrDefault(kvp => StringComparer.OrdinalIgnoreCase.Equals(kvp.Key, entry.Scope)).Value?.DisplayName;
 
             return !String.IsNullOrWhiteSpace(displayName) ? displayName : entry.Scope;
         }


### PR DESCRIPTION
Change configuration file format to allow overriding of settings for individual scopes without having to repeat values specified in the default settings.

This changes the `scopes` setting in the configuration file from a JSON array to a JSON object. The settings for a specific scope are modeled as a property on the JSON object named like the footer the settings apply to.
This allows overriding the settings for a scope based on its name rather than its position in the list (e.g. when specifying scope settings as environment variables).

💥 BREAKING CHANGE: Changes the configuration file format for scopes. Configuration files intended for v0.2 need to be updated to the new format manually.

- [x] Adjust configuration format to allow overriding of settings for individual footers
- [x] Additional validation of footer settings
- [x] Adjust ConfigurationLoader to ignore v0.2 settings
- [x] Update docs
- [x] Update `changelog.settings.json`
