### PR TITLE
feat: Auto-locate the repository directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Thanks to all the people contributing to these projects:
 - [Scriban](https://github.com/lunet-io/scriban)
 - [Spectre.Console](https://spectresystems.github.io/spectre.console/)
 - [Xunit.Combinatorial](https://github.com/AArnott/Xunit.Combinatorial)
+- [CliWrap](https://github.com/Tyrrrz/CliWrap)
 
 ## Versioning and Branching
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
     displayName: 'Install .NET Core 3.1 runtime'
     inputs:
       packageType: runtime
-      version: 3.1.x      
+      version: 3.1.x
 
   # Restore local .NET Core tools
   - task: DotNetCoreCLI@2
@@ -206,8 +206,8 @@ jobs:
       command: run
       arguments: >-
         --project ./src/ChangeLog/Grynwald.ChangeLog.csproj
-        --framework netcoreapp3.1
-        --repository $(Build.SourcesDirectory)
+        --framework net5.0
+        --
         --currentVersion $(NBGV_NuGetPackageVersion)
         --versionRange [$(NBGV_NuGetPackageVersion)]
         --outputpath $(Build.StagingDirectory)/changelog.md

--- a/docs/commandline-reference/index.md
+++ b/docs/commandline-reference/index.md
@@ -15,7 +15,7 @@ changelog [--configurationFilePath|-c <VALUE>]
           [--githubAccessToken <VALUE>]
           [--gitlabAccessToken <VALUE>]
           [--outputPath|-o <VALUE>]
-          --repository|-r <VALUE>
+          [--repository|-r <VALUE>]
           [--template <VALUE>]
           [--versionRange <VALUE>]
           [--verbose|-v]
@@ -23,17 +23,17 @@ changelog [--configurationFilePath|-c <VALUE>]
 
 ## Parameters
 
-| Name                                                      | Short Name                            | Required | Description                                                                                                                                                                                                                                    |
-| --------------------------------------------------------- | ------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [configurationFilePath](#configurationfilepath-parameter) | [c](#configurationfilepath-parameter) | No       | The path of the configuration file to use. When no configuration file path is specified, changelog looks for a file named 'changelog.settings.json' in the repository directory. If no configuration file is found, default settings are used. |
-| [currentVersion](#currentversion-parameter)               |                                       | No       | Sets the version of the currently checked\-out commit. Value must be a valid semantic version                                                                                                                                                  |
-| [githubAccessToken](#githubaccesstoken-parameter)         |                                       | No       | The access token to use if the GitHub integration is enabled.                                                                                                                                                                                  |
-| [gitlabAccessToken](#gitlabaccesstoken-parameter)         |                                       | No       | The access token to use if the GitLab integration is enabled.                                                                                                                                                                                  |
-| [outputPath](#outputpath-parameter)                       | [o](#outputpath-parameter)            | No       | The path to save the changelog to.                                                                                                                                                                                                             |
-| [repository](#repository-parameter)                       | [r](#repository-parameter)            | Yes      | The local path of the git repository to generate a change log for.                                                                                                                                                                             |
-| [template](#template-parameter)                           |                                       | No       | Sets the template to use for generating the changelog.                                                                                                                                                                                         |
-| [versionRange](#versionrange-parameter)                   |                                       | No       | The range of versions to include in the change log. Value must be a valid NuGet version range.                                                                                                                                                 |
-| [verbose](#verbose-parameter)                             | [v](#verbose-parameter)               | No       | Increase the level of detail for messages logged to the console.                                                                                                                                                                               |
+| Name                                                      | Short Name                            | Description                                                                                                                                                                                                                                    |
+| --------------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [configurationFilePath](#configurationfilepath-parameter) | [c](#configurationfilepath-parameter) | The path of the configuration file to use. When no configuration file path is specified, changelog looks for a file named 'changelog.settings.json' in the repository directory. If no configuration file is found, default settings are used. |
+| [currentVersion](#currentversion-parameter)               |                                       | Sets the version of the currently checked\-out commit. Value must be a valid semantic version                                                                                                                                                  |
+| [githubAccessToken](#githubaccesstoken-parameter)         |                                       | The access token to use if the GitHub integration is enabled.                                                                                                                                                                                  |
+| [gitlabAccessToken](#gitlabaccesstoken-parameter)         |                                       | The access token to use if the GitLab integration is enabled.                                                                                                                                                                                  |
+| [outputPath](#outputpath-parameter)                       | [o](#outputpath-parameter)            | The path to save the changelog to.                                                                                                                                                                                                             |
+| [repository](#repository-parameter)                       | [r](#repository-parameter)            | The local path of the git repository to generate a change log for.                                                                                                                                                                             |
+| [template](#template-parameter)                           |                                       | Sets the template to use for generating the changelog.                                                                                                                                                                                         |
+| [versionRange](#versionrange-parameter)                   |                                       | The range of versions to include in the change log. Value must be a valid NuGet version range.                                                                                                                                                 |
+| [verbose](#verbose-parameter)                             | [v](#verbose-parameter)               | Increase the level of detail for messages logged to the console.                                                                                                                                                                               |
 
 ### `configurationFilePath` Parameter
 
@@ -111,7 +111,7 @@ The local path of the git repository to generate a change log for.
 | Name:          | repository        |
 | Short name:    | r                 |
 | Position:      | *Named parameter* |
-| Required:      | Yes               |
+| Required:      | No                |
 | Default value: | *None*            |
 
 ___

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ To install ChangeLog, run:
 dotnet tool install -g Grynwald.ChangeLog
 ```
 
-## Generating a changelog
+## Generating a change log
 
 ChangeLog assumes you have a local git repository which's commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
 
@@ -26,14 +26,16 @@ Versions need to follow the [Semantic Versioning](https://semver.org/) format.
 By default all tag names that are semantic versions and tag names that are semantic versions prefixed with `v` are recognized (e.g. `1.2.3-alpha` or `v1.2`).
 Parsing of tags can be customized using the [Tag Patterns Setting](./configuration/settings/tag-patterns.md).
 
-To generate a changelog from a git repository, run Changelog and specify the path to the git repository.
-By default, the change log is saved to `changelog.md` in the repository.
+To generate a change log from a git repository, run ChangeLog and specify the path to the git repository.
 
 ```sh
 changelog --repository <LOCALPATH>
 ```
 
-You can override the output path using the `--outputPath` parameters.
+ℹ The repository path can be omitted when `changelog` is run from a directory within the git repository.
+
+By default, the change log is saved to `changelog.md` in the repository.
+You can override the output path using the `--outputPath` parameter or in the configuration file (see [Configuration](./configuration.md)).
 
 For all full list of commandline parameters, see
 [Commandline reference](./commandline-reference/index.md)

--- a/src/ChangeLog.Test/CommandExtentsions.cs
+++ b/src/ChangeLog.Test/CommandExtentsions.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using CliWrap;
+using CliWrap.Buffered;
+using Xunit.Abstractions;
+
+namespace Grynwald.ChangeLog.Test
+{
+    /// <summary>
+    /// Extension methods for <see cref="CliWrap.Command"/>
+    /// </summary>
+    public static class CommandExtentsions
+    {
+        public static Command AddTestOutputPipe(this Command command, ITestOutputHelper testOutputHelper)
+        {
+            return command
+                .WithStandardOutputPipe(
+                     PipeTarget.Merge(
+                        command.StandardOutputPipe,
+                        PipeTarget.ToDelegate(testOutputHelper.WriteLine)))
+                .WithStandardErrorPipe(
+                    PipeTarget.Merge(
+                    command.StandardErrorPipe,
+                    PipeTarget.ToDelegate(testOutputHelper.WriteLine)));
+        }
+
+        public static async Task<BufferedCommandResult> ExecuteBufferedWithTestOutputAsync(this Command command, ITestOutputHelper testOutputHelper)
+        {
+            command = command.AddTestOutputPipe(testOutputHelper);
+
+            testOutputHelper.WriteLine("------------------------------------------------------------");
+            testOutputHelper.WriteLine($"BEGIN Command '{command.TargetFilePath} {command.Arguments}'");
+            testOutputHelper.WriteLine($"Working directory: '{command.WorkingDirPath}'");
+            testOutputHelper.WriteLine("------------------------------------------------------------");
+
+            var result = await command.ExecuteBufferedAsync();
+
+            testOutputHelper.WriteLine("------------------------------------------------------------");
+            testOutputHelper.WriteLine($"END Command, exit code: {result.ExitCode}");
+            testOutputHelper.WriteLine("------------------------------------------------------------");
+            testOutputHelper.WriteLine("");
+
+            return result;
+        }
+    }
+}

--- a/src/ChangeLog.Test/CommandLineParametersTest.cs
+++ b/src/ChangeLog.Test/CommandLineParametersTest.cs
@@ -15,27 +15,25 @@ namespace Grynwald.ChangeLog.Test
     /// </summary>
     public class CommandLineParametersTest
     {
-        public static IEnumerable<object[]> Properties()
-        {
-            foreach (var property in typeof(CommandLineParameters).GetProperties())
-            {
-                // the "--verbose" switch has no corresponding configuration setting
-                if (property.Name == nameof(CommandLineParameters.Verbose))
-                    continue;
-
-                // the "--configurationPath" parameter has no corresponding configuration setting
-                if (property.Name == nameof(CommandLineParameters.ConfigurationFilePath))
-                    continue;
-
-                yield return new[] { property.Name };
-            }
-        }
+        public static IEnumerable<object[]> Properties() =>
+            typeof(CommandLineParameters).GetProperties().Select(p => new[] { p.Name });
 
         [Theory]
         [MemberData(nameof(Properties))]
         public void Properties_have_a_configuration_value_attribute(string propertyName)
         {
-            // all properties inCommandLineParameters should have a ConfigurationValueAttribute
+            // the "--verbose", "--configurationPath"  and "--repositoryPath"
+            // switches haveno corresponding configuration setting and are
+            // processed before the configuration system is initialized
+
+            if (propertyName == nameof(CommandLineParameters.Verbose) ||
+                propertyName == nameof(CommandLineParameters.ConfigurationFilePath) ||
+                propertyName == nameof(CommandLineParameters.RepositoryPath))
+            {
+                return;
+            }
+
+            // All other properties in CommandLineParameters should have a ConfigurationValue attribute
             // so the value can be used in the configuration system.
 
             var property = typeof(CommandLineParameters).GetProperty(propertyName)!;

--- a/src/ChangeLog.Test/CommandLineParametersValidatorTest.cs
+++ b/src/ChangeLog.Test/CommandLineParametersValidatorTest.cs
@@ -9,9 +9,28 @@ namespace Grynwald.ChangeLog.Test
         [Theory]
         [InlineData("")]
         [InlineData(null)]
+        public void RepositoryPath_may_be_empty(string repositoryPath)
+        {
+            // ARRANGE
+            var parameters = new CommandLineParameters()
+            {
+                RepositoryPath = repositoryPath
+            };
+
+            var validator = new CommandLineParametersValidator();
+
+            // ACT 
+            var result = validator.Validate(parameters);
+
+            // ASSERT
+            Assert.True(result.IsValid);
+            Assert.Empty(result.Errors);
+        }
+
+        [Theory]
         [InlineData("  ")]
         [InlineData("\t")]
-        public void RepositoryPath_must_not_be_null_or_empty(string repositoryPath)
+        public void RepositoryPath_must__not_be_whitespace(string repositoryPath)
         {
             // ARRANGE
             var parameters = new CommandLineParameters()

--- a/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
+++ b/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
@@ -380,6 +380,30 @@ namespace Grynwald.ChangeLog.Test.Configuration
             Assert.Equal("7.8.9", config.CurrentVersion);
         }
 
+        [Fact]
+        public void Values_from_settings_objects_override_values_from_earlier_settings_objects()
+        {
+            // ARRANGE
+            PrepareConfiguration("currentVersion", "1.2.3");
+
+            var settingsObject1 = new TestSettingsClass()
+            {
+                CurrentVersion = "4.5.6"
+            };
+            var settingsObject2 = new TestSettingsClass()
+            {
+                CurrentVersion = "7.8.9"
+            };
+
+            // ACT
+            var config = ChangeLogConfigurationLoader.GetConfiguration(m_ConfigurationFilePath, settingsObject1, settingsObject2);
+
+            // ASSERT
+            Assert.NotNull(config.CurrentVersion);
+            Assert.Equal("7.8.9", config.CurrentVersion);
+        }
+
+
         [Flags]
         private enum SettingsTarget
         {
@@ -731,7 +755,7 @@ namespace Grynwald.ChangeLog.Test.Configuration
             var settingsObject = Activator.CreateInstance(dynamicAssembly.GetType("SettingsObject")!, new object[] { expectedValue });
 
             // ACT 
-            var config = ChangeLogConfigurationLoader.GetConfiguration(m_ConfigurationFilePath, settingsObject);
+            var config = ChangeLogConfigurationLoader.GetConfiguration(m_ConfigurationFilePath, settingsObject!);
 
             // ASSERT
             if (assert is null)

--- a/src/ChangeLog.Test/E2E/E2ETests.cs
+++ b/src/ChangeLog.Test/E2E/E2ETests.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using CliWrap;
+using CliWrap.Buffered;
+using Grynwald.ChangeLog.Test.Git;
+using Grynwald.Utilities.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Grynwald.ChangeLog.Test.E2E
+{
+    /// <summary>
+    /// End-to-End tests that run "changelog" as a separate process on a real (created for the test) git repository
+    /// </summary>
+    public class E2ETests
+    {
+        private readonly ITestOutputHelper m_TestOutputHelper;
+
+        public E2ETests(ITestOutputHelper testOutputHelper)
+        {
+            m_TestOutputHelper = testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
+        }
+
+
+        [Fact]
+        public async Task Requesting_help_succeeds()
+        {
+            // ARRANGE
+            var applicationVersion = typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+            // ACT 
+            var result = await RunApplicationAsync(new[] { "--help" });
+
+            // ASSERT
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains($"changelog {applicationVersion}{Environment.NewLine}", result.StandardOutput);
+            Assert.Contains("-r, --repository", result.StandardOutput);
+            Assert.Contains("-c, --configurationFilePath", result.StandardOutput);
+            Assert.Contains("-o, --outputPath", result.StandardOutput);
+            Assert.Contains("--githubAccessToken", result.StandardOutput);
+            Assert.Contains("--gitlabAccessToken", result.StandardOutput);
+            Assert.Contains("--versionRange", result.StandardOutput);
+            Assert.Contains("--currentVersion", result.StandardOutput);
+            Assert.Contains("--template", result.StandardOutput);
+            Assert.Contains("--help", result.StandardOutput);
+            Assert.Contains("--version", result.StandardOutput);
+            Assert.Empty(result.StandardError);
+        }
+
+        [Fact]
+        public async Task Requesting_version_succeeds()
+        {
+            // ARRANGE
+            var expectedVersion = typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+            // ACT 
+            var result = await RunApplicationAsync(new[] { "--version" });
+
+            // ASSERT
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal($"changelog {expectedVersion}", result.StandardOutput.Trim());
+            Assert.Empty(result.StandardError);
+        }
+
+        [Fact]
+        public async Task Generate_change_log_with_default_configuration()
+        {
+            // ARRANGE
+            using var temporaryDirectory = new TemporaryDirectory();
+
+            var git = new GitWrapper(temporaryDirectory, m_TestOutputHelper);
+            await git.InitAsync();
+            await git.ConfigAsync("user.name", "Example");
+            await git.ConfigAsync("user.email", "user@example.com");
+
+            var commit = await git.CommitAsync("feat: Some New feature");
+            await git.TagAsync("v1.0.0", commit);
+
+            var expectedOutputPath = Path.Combine(temporaryDirectory, "changelog.md");
+            var expectedOutput = String.Join(Environment.NewLine,
+                "# Change Log",
+                "",
+                "## 1.0.0",
+                "",
+                $"#### <a id=\"changelog-heading-{commit.Id.Id}\"></a> Some New feature",
+                "",
+                $"- Commit: `{commit.Id.AbbreviatedId}`",
+                "");
+
+            // ACT 
+            var result = await RunApplicationAsync(new[] { "--repository", temporaryDirectory });
+
+            // ASSERT
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(File.Exists(expectedOutputPath));
+            Assert.Equal(expectedOutput, File.ReadAllText(expectedOutputPath));
+        }
+
+
+        /// <summary>
+        /// Runs changelog with the specified command line parameters
+        /// </summary>
+        private async Task<BufferedCommandResult> RunApplicationAsync(string[] args)
+        {
+            var applicationAssembly = typeof(Program).Assembly;
+
+            // The application is published to the test output directory into the "Grynwald.ChangeLog" directory
+            var assemblyPath = Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+                "Grynwald.ChangeLog",
+                Path.GetFileName(applicationAssembly.Location));
+
+            // 
+            // Note: It is important to use the changelog.dll from the test directory rather
+            // than the copy from the applications build output directory.
+            // Coverlet instruments all assemblies in the test directory in order to compute the tests' code coverage.
+            // When running the instrumented assembly (even in a child process),
+            // the covered lines will be included in the computed coverage.
+            //
+            // If the test ran the changelog.dll copied to the publsih directory
+            // the test would still work but would not be included in the computed code coverage.
+            //
+            // To resolve that, replace the changelog assembly in the publish directory with the instrumened assembly
+            File.Copy(applicationAssembly.Location, assemblyPath, true);
+
+            var command = Cli.Wrap("dotnet")
+                .WithArguments(dotnetArgs => dotnetArgs
+                    .Add(assemblyPath)
+                    .Add(args))
+                .WithValidation(CommandResultValidation.None);
+
+            var result = await command.ExecuteBufferedWithTestOutputAsync(m_TestOutputHelper);
+
+            return result;
+        }
+    }
+}

--- a/src/ChangeLog.Test/Git/GitRepositoryTest.cs
+++ b/src/ChangeLog.Test/Git/GitRepositoryTest.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using Grynwald.ChangeLog.Git;
 using Grynwald.Utilities.IO;
 using Xunit;
@@ -14,16 +12,21 @@ namespace Grynwald.ChangeLog.Test.Git
     /// </summary>
     public class GitRepositoryTest : IDisposable
     {
-        private readonly TemporaryDirectory m_WorkingDirectory = new TemporaryDirectory();
-        private readonly ITestOutputHelper m_TestOutputHelper;
+        private readonly TemporaryDirectory m_WorkingDirectory;
+
+        private GitWrapper Git { get; }
 
         public GitRepositoryTest(ITestOutputHelper testOutputHelper)
         {
-            m_TestOutputHelper = testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
+            if (testOutputHelper is null)
+                throw new ArgumentNullException(nameof(testOutputHelper));
 
-            Git("init");
-            Git("config --local user.name Example");
-            Git("config --local user.email user@example.com");
+            m_WorkingDirectory = new TemporaryDirectory();
+            Git = new GitWrapper(m_WorkingDirectory, testOutputHelper);
+
+            Git.Init();
+            Git.Config("user.name", "Example");
+            Git.Config("user.email", "user@example.com");
         }
 
         public void Dispose() => m_WorkingDirectory.Dispose();
@@ -57,8 +60,8 @@ namespace Grynwald.ChangeLog.Test.Git
         public void Remotes_returns_expected_remotes_02()
         {
             // ARRANGE
-            Git("remote add origin https://example.com/origin");
-            Git("remote add upstream https://example.com/upstream");
+            Git.AddRemote("origin", "https://example.com/origin");
+            Git.AddRemote("upstream", "https://example.com/upstream");
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -76,7 +79,7 @@ namespace Grynwald.ChangeLog.Test.Git
         public void Head_returns_expected_commit()
         {
             // ARRANGE            
-            var expectedHead = GitCommit("Initialize repository");
+            var expectedHead = Git.Commit("Initialize repository");
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -106,13 +109,13 @@ namespace Grynwald.ChangeLog.Test.Git
         public void GetTags_returns_expected_tags_02()
         {
             // ARRANGE
-            var commit1 = GitCommit("First commit");
-            var commit2 = GitCommit("Second commit");
-            var commit3 = GitCommit("Third commit");
+            var commit1 = Git.Commit("First commit");
+            var commit2 = Git.Commit("Second commit");
+            var commit3 = Git.Commit("Third commit");
 
-            var tag1 = GitTag("tag1", commit1);
-            var tag2 = GitTag("tag2", commit2);
-            var tag3 = GitTag("tag3", commit3);
+            var tag1 = Git.Tag("tag1", commit1);
+            var tag2 = Git.Tag("tag2", commit2);
+            var tag3 = Git.Tag("tag3", commit3);
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -131,7 +134,7 @@ namespace Grynwald.ChangeLog.Test.Git
         public void GetCommits_returns_the_expected_commits_01()
         {
             // ARRANGE
-            var expectedCommit = GitCommit("commit 1");
+            var expectedCommit = Git.Commit("commit 1");
             using var sut = new GitRepository(m_WorkingDirectory);
 
             // ACT 
@@ -147,9 +150,9 @@ namespace Grynwald.ChangeLog.Test.Git
         public void GetCommits_returns_the_expected_commits_02()
         {
             // ARRANGE
-            var expectedCommit1 = GitCommit("commit 1");
-            var expectedCommit2 = GitCommit("commit 2");
-            var expectedCommit3 = GitCommit("commit 3");
+            var expectedCommit1 = Git.Commit("commit 1");
+            var expectedCommit2 = Git.Commit("commit 2");
+            var expectedCommit3 = Git.Commit("commit 3");
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -168,13 +171,13 @@ namespace Grynwald.ChangeLog.Test.Git
         public void GetCommits_returns_the_expected_commits_03()
         {
             // ARRANGE
-            var expectedCommit1 = GitCommit("commit 1");
-            Git("checkout -b branch1");
-            var expectedCommit2 = GitCommit("commit 2");
-            var expectedCommit3 = GitCommit("commit 3");
-            Git("checkout -");
-            var expectedCommit4 = GitCommit("commit 4");
-            var expectedCommit5 = GitCommit("commit 5");
+            var expectedCommit1 = Git.Commit("commit 1");
+            Git.CheckoutNewBranch("branch1");
+            var expectedCommit2 = Git.Commit("commit 2");
+            var expectedCommit3 = Git.Commit("commit 3");
+            Git.Checkout("-");
+            var expectedCommit4 = Git.Commit("commit 4");
+            var expectedCommit5 = Git.Commit("commit 5");
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -193,10 +196,10 @@ namespace Grynwald.ChangeLog.Test.Git
         public void GetCommits_returns_the_expected_commits_04()
         {
             // ARRANGE
-            var expectedCommit1 = GitCommit("commit 1");
-            var expectedCommit2 = GitCommit("commit 2");
-            var expectedCommit3 = GitCommit("commit 3");
-            var expectedCommit4 = GitCommit("commit 4");
+            var expectedCommit1 = Git.Commit("commit 1");
+            var expectedCommit2 = Git.Commit("commit 2");
+            var expectedCommit3 = Git.Commit("commit 3");
+            var expectedCommit4 = Git.Commit("commit 4");
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -214,13 +217,13 @@ namespace Grynwald.ChangeLog.Test.Git
         public void GetCommits_returns_the_expected_commits_05()
         {
             // ARRANGE
-            var expectedCommit1 = GitCommit("commit 1");
-            Git("checkout -b branch1");
-            var expectedCommit2 = GitCommit("commit 2");
-            var expectedCommit3 = GitCommit("commit 3");
-            Git("checkout -");
-            var expectedCommit4 = GitCommit("commit 4");
-            var expectedCommit5 = GitCommit("commit 5");
+            var expectedCommit1 = Git.Commit("commit 1");
+            Git.CheckoutNewBranch("branch1");
+            var expectedCommit2 = Git.Commit("commit 2");
+            var expectedCommit3 = Git.Commit("commit 3");
+            Git.Checkout("-");
+            var expectedCommit4 = Git.Commit("commit 4");
+            var expectedCommit5 = Git.Commit("commit 5");
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -260,8 +263,8 @@ namespace Grynwald.ChangeLog.Test.Git
         public void TryGetCommit_returns_the_expected_commit(int idLength)
         {
             // ARRANGE
-            var expectedCommit = GitCommit("Commit 1");
-            _ = GitCommit("Commit 2");
+            var expectedCommit = Git.Commit("Commit 1");
+            _ = Git.Commit("Commit 2");
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -279,8 +282,8 @@ namespace Grynwald.ChangeLog.Test.Git
         public void TryGetCommit_returns_null_if_commit_cannot_be_found(string id)
         {
             // ARRANGE
-            _ = GitCommit("Commit 1");
-            _ = GitCommit("Commit 2");
+            _ = Git.Commit("Commit 1");
+            _ = Git.Commit("Commit 2");
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -295,8 +298,8 @@ namespace Grynwald.ChangeLog.Test.Git
         public void TryGetCommit_is_case_insensitive()
         {
             // ARRANGE
-            var expectedCommit = GitCommit("Commit 1");
-            _ = GitCommit("Commit 2");
+            var expectedCommit = Git.Commit("Commit 1");
+            _ = Git.Commit("Commit 2");
 
             using var sut = new GitRepository(m_WorkingDirectory);
 
@@ -309,96 +312,6 @@ namespace Grynwald.ChangeLog.Test.Git
         }
 
 
-        private GitTag GitTag(string name, GitCommit commit)
-        {
-            Git($"tag {name} {commit.Id}");
-            return new GitTag(name, commit.Id);
-        }
 
-        private GitCommit GitCommit(string commitMessage)
-        {
-            Git($"commit --allow-empty -m \"{commitMessage}\"");
-            Git("config --local user.name", out var userName);
-            Git("config --local user.email", out var userEmail);
-            Git("rev-parse HEAD", out var commitId);
-            Git("rev-parse --short HEAD", out var abbreviatedCommitId);
-            Git("log -1 --pretty=\"format:%cI\" ", out var date);
-
-            return new GitCommit(
-                new GitId(commitId.Trim(), abbreviatedCommitId.Trim()),
-                $"{commitMessage}\n",
-                DateTime.Parse(date.Trim()),
-                new GitAuthor(userName.Trim(), userEmail.Trim())
-            );
-        }
-
-        private void Git(string command) =>
-            Git(command, out _, out _);
-
-        private void Git(string command, out string stdOut) =>
-            Git(command, out stdOut, out _);
-
-        private void Git(string command, out string stdOut, out string stdErr)
-        {
-            var startInfo = new ProcessStartInfo()
-            {
-                FileName = "git",
-                Arguments = command,
-                WorkingDirectory = m_WorkingDirectory,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
-
-            var stdOutBuilder = new StringBuilder();
-            var stdErrBuilder = new StringBuilder();
-
-            var process = Process.Start(startInfo);
-
-            if (process is null)
-                throw new InvalidOperationException("Failed to start git process. Process.Start() returned null");
-
-            process.ErrorDataReceived += (s, e) =>
-            {
-                if (e.Data is string)
-                    stdErrBuilder.AppendLine(e.Data);
-            };
-
-            process.OutputDataReceived += (s, e) =>
-            {
-                if (e.Data is string)
-                    stdOutBuilder.AppendLine(e.Data);
-            };
-
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
-
-            process.WaitForExit();
-
-            process.CancelErrorRead();
-            process.CancelOutputRead();
-
-            stdOut = stdOutBuilder.ToString();
-            stdErr = stdErrBuilder.ToString();
-
-            m_TestOutputHelper.WriteLine("--------------------------------");
-            m_TestOutputHelper.WriteLine($"Begin Command 'git {command}'");
-            m_TestOutputHelper.WriteLine("--------------------------------");
-            m_TestOutputHelper.WriteLine("StdOut:");
-            m_TestOutputHelper.WriteLine(stdOut);
-            m_TestOutputHelper.WriteLine("StdErr:");
-            m_TestOutputHelper.WriteLine(stdErr);
-            m_TestOutputHelper.WriteLine("--------------------------------");
-            m_TestOutputHelper.WriteLine($"End Command 'git {command}'");
-            m_TestOutputHelper.WriteLine("--------------------------------");
-
-
-            if (process.ExitCode != 0)
-            {
-                throw new Exception($"Command 'git {command}' completed with exit code {process.ExitCode}");
-            }
-
-        }
     }
 }

--- a/src/ChangeLog.Test/Git/GitRepositoryTest.cs
+++ b/src/ChangeLog.Test/Git/GitRepositoryTest.cs
@@ -52,6 +52,19 @@ namespace Grynwald.ChangeLog.Test.Git
         }
 
         [Fact]
+        public void Constructor_throws_RepositoryNotFoundException_when_repository_path_is_not_a_git_repository()
+        {
+            // ARRANGE
+            using var temporaryDirectory = new TemporaryDirectory();
+
+            // ACT 
+            var ex = Record.Exception(() => new GitRepository(temporaryDirectory));
+
+            // ASSERT
+            Assert.IsType<RepositoryNotFoundException>(ex);
+        }
+
+        [Fact]
         public void Remotes_returns_expected_remotes_01()
         {
             // ARRANGE            

--- a/src/ChangeLog.Test/Git/GitWrapper.cs
+++ b/src/ChangeLog.Test/Git/GitWrapper.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+using Grynwald.ChangeLog.Git;
+using Xunit.Abstractions;
+
+namespace Grynwald.ChangeLog.Test.Git
+{
+    /// <summary>
+    /// Provides an wrapper around the git CLI for testing
+    /// </summary>
+    internal class GitWrapper
+    {
+        private readonly string m_WorkingDirectory;
+        private readonly ITestOutputHelper m_Output;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="GitWrapper"/>
+        /// </summary>
+        /// <param name="workingDirectory">The working directory to start git commands in</param>
+        /// <param name="output">The output helper to write git's output to.</param>
+        public GitWrapper(string workingDirectory, ITestOutputHelper output)
+        {
+            if (String.IsNullOrWhiteSpace(workingDirectory))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(workingDirectory));
+
+            m_WorkingDirectory = workingDirectory;
+            m_Output = output ?? throw new ArgumentNullException(nameof(output));
+        }
+
+
+        /// <summary>
+        /// Initializes a new git repository in the working directory
+        /// </summary>
+        public void Init() => Exec("init");
+
+        /// <summary>
+        /// Creates a new commit
+        /// </summary>
+        public GitCommit Commit(string commitMessage)
+        {
+            Exec($"commit --allow-empty -m \"{commitMessage}\"");
+            Exec("config --local user.name", out var userName);
+            Exec("config --local user.email", out var userEmail);
+            Exec("rev-parse HEAD", out var commitId);
+            Exec("rev-parse --short HEAD", out var abbreviatedCommitId);
+            Exec("log -1 --pretty=\"format:%cI\" ", out var date);
+
+            return new GitCommit(
+                new GitId(commitId.Trim(), abbreviatedCommitId.Trim()),
+                $"{commitMessage}\n",
+                DateTime.Parse(date.Trim()),
+                new GitAuthor(userName.Trim(), userEmail.Trim())
+            );
+        }
+
+        /// <summary>
+        /// Creates a new git tag
+        /// </summary>
+        public GitTag Tag(string name, GitCommit commit)
+        {
+            Exec($"tag {name} {commit.Id}");
+            return new GitTag(name, commit.Id);
+        }
+
+        /// <summary>
+        /// Sets the specified git setting to the specified value.
+        /// </summary>
+        public void Config(string name, string value) => Exec($"config --local \"{name}\" \"{value}\"");
+
+        /// <summary>
+        /// Adds the specified remote to the repository
+        /// </summary>
+        public void AddRemote(string name, string url) => Exec($"remote add \"{name}\" \"{url}\"");
+
+        /// <summary>
+        /// Perfoms a git checkout operation
+        /// </summary>
+        /// <param name="ref">The git reference to check out</param>
+        public void Checkout(string @ref) => Exec($"checkout \"{@ref}\"");
+
+        /// <summary>
+        /// Checks out a new branch created from the current HEAD commit
+        /// </summary
+        public void CheckoutNewBranch(string branchName) => Exec($"checkout -b \"{branchName}\"");
+
+
+        private void Exec(string command) =>
+            Exec(command, out _, out _);
+
+        private void Exec(string command, out string stdOut) =>
+            Exec(command, out stdOut, out _);
+
+        private void Exec(string command, out string stdOut, out string stdErr)
+        {
+            var startInfo = new ProcessStartInfo()
+            {
+                FileName = "git",
+                Arguments = command,
+                WorkingDirectory = m_WorkingDirectory,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            var stdOutBuilder = new StringBuilder();
+            var stdErrBuilder = new StringBuilder();
+
+            var process = Process.Start(startInfo);
+
+            if (process is null)
+                throw new InvalidOperationException("Failed to start git process. Process.Start() returned null");
+
+            process.ErrorDataReceived += (s, e) =>
+            {
+                if (e.Data is string)
+                    stdErrBuilder.AppendLine(e.Data);
+            };
+
+            process.OutputDataReceived += (s, e) =>
+            {
+                if (e.Data is string)
+                    stdOutBuilder.AppendLine(e.Data);
+            };
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            process.WaitForExit();
+
+            process.CancelErrorRead();
+            process.CancelOutputRead();
+
+            stdOut = stdOutBuilder.ToString();
+            stdErr = stdErrBuilder.ToString();
+
+            m_Output.WriteLine("--------------------------------");
+            m_Output.WriteLine($"Begin Command 'git {command}'");
+            m_Output.WriteLine("--------------------------------");
+            m_Output.WriteLine("StdOut:");
+            m_Output.WriteLine(stdOut);
+            m_Output.WriteLine("StdErr:");
+            m_Output.WriteLine(stdErr);
+            m_Output.WriteLine("--------------------------------");
+            m_Output.WriteLine($"End Command 'git {command}'");
+            m_Output.WriteLine("--------------------------------");
+
+
+            if (process.ExitCode != 0)
+            {
+                throw new Exception($"Command 'git {command}' completed with exit code {process.ExitCode}");
+            }
+
+        }
+    }
+}

--- a/src/ChangeLog.Test/Git/GitWrapper.cs
+++ b/src/ChangeLog.Test/Git/GitWrapper.cs
@@ -33,7 +33,7 @@ namespace Grynwald.ChangeLog.Test.Git
         /// <summary>
         /// Initializes a new git repository in the working directory
         /// </summary>
-        public Task InitAsync() => ExecAsync("init");
+        public Task InitAsync(bool createBareRepository = false) => ExecAsync($"init {(createBareRepository ? "--bare" : "")}");
 
         /// <summary>
         /// Creates a new commit

--- a/src/ChangeLog.Test/Git/RepositoryLocatorTest.cs
+++ b/src/ChangeLog.Test/Git/RepositoryLocatorTest.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.IO;
+using Grynwald.ChangeLog.Git;
+using Grynwald.Utilities.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Grynwald.ChangeLog.Test.Git
+{
+    /// <summary>
+    /// Tests for <see cref="RepositoryLocator"/>
+    /// </summary>
+    public class RepositoryLocatorTest
+    {
+        private readonly ITestOutputHelper m_TestOutputHelper;
+
+        public RepositoryLocatorTest(ITestOutputHelper testOutputHelper)
+        {
+            m_TestOutputHelper = testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
+        }
+
+        [Fact]
+        public void TryGetRepositoryPath_succeeds_when_starting_path_is_a_git_repository()
+        {
+            // ARRANGE
+            using var temporaryDirectory = new TemporaryDirectory();
+            var git = new GitWrapper(temporaryDirectory, m_TestOutputHelper);
+            git.Init();
+
+            var expectedRepositoryPath = Path.Combine(temporaryDirectory, ".git");
+
+            // ACT 
+            var success = RepositoryLocator.TryGetRepositoryPath(temporaryDirectory, out var actualRepositoryPath);
+
+            // ASSERT
+            Assert.True(success);
+            Assert.Equal(expectedRepositoryPath, actualRepositoryPath?.TrimEnd(Path.DirectorySeparatorChar));
+        }
+
+        [Theory]
+        [InlineData("subdir")]
+        [InlineData("subdir/dir2")]
+        [InlineData("subdir/dir2/dir3")]
+        [InlineData("subdir/dir2/./dir3")]
+        [InlineData("subdir/dir2/../dir3")]
+        public void TryGetRepositoryPath_succeeds_when_starting_path_is_a_subdirectory_of_git_repository(string relativePath)
+        {
+            // ARRANGE
+            using var temporaryDirectory = new TemporaryDirectory();
+            var git = new GitWrapper(temporaryDirectory, m_TestOutputHelper);
+            git.Init();
+
+            var expectedRepositoryPath = Path.Combine(temporaryDirectory, ".git");
+            var startingPath = temporaryDirectory.AddSubDirectory(relativePath);
+
+            // ACT 
+            var success = RepositoryLocator.TryGetRepositoryPath(startingPath, out var actualRepositoryPath);
+
+            // ASSERT
+            Assert.True(success);
+            Assert.Equal(expectedRepositoryPath, actualRepositoryPath?.TrimEnd(Path.DirectorySeparatorChar));
+        }
+
+        [Fact]
+        public void TryGetRepositoryPath_fails_when_starting_path_is_not_a_git_repository()
+        {
+            // ARRANGE
+            using var temporaryDirectory = new TemporaryDirectory();
+
+            // ACT 
+            var success = RepositoryLocator.TryGetRepositoryPath(temporaryDirectory, out var actualRepositoryPath);
+
+            // ASSERT
+            Assert.False(success);
+            Assert.Null(actualRepositoryPath);
+        }
+    }
+}

--- a/src/ChangeLog.Test/Git/RepositoryLocatorTest.cs
+++ b/src/ChangeLog.Test/Git/RepositoryLocatorTest.cs
@@ -29,14 +29,12 @@ namespace Grynwald.ChangeLog.Test.Git
             var git = new GitWrapper(temporaryDirectory, m_TestOutputHelper);
             await git.InitAsync();
 
-            var expectedRepositoryPath = Path.Combine(temporaryDirectory, ".git");
-
             // ACT 
             var success = RepositoryLocator.TryGetRepositoryPath(temporaryDirectory, out var actualRepositoryPath);
 
             // ASSERT
             Assert.True(success);
-            Assert.Equal(expectedRepositoryPath, actualRepositoryPath?.TrimEnd(Path.DirectorySeparatorChar));
+            Assert.Equal(temporaryDirectory, actualRepositoryPath?.TrimEnd(Path.DirectorySeparatorChar));
         }
 
         [Theory]
@@ -52,7 +50,6 @@ namespace Grynwald.ChangeLog.Test.Git
             var git = new GitWrapper(temporaryDirectory, m_TestOutputHelper);
             await git.InitAsync();
 
-            var expectedRepositoryPath = Path.Combine(temporaryDirectory, ".git");
             var startingPath = temporaryDirectory.AddSubDirectory(relativePath);
 
             // ACT 
@@ -60,7 +57,7 @@ namespace Grynwald.ChangeLog.Test.Git
 
             // ASSERT
             Assert.True(success);
-            Assert.Equal(expectedRepositoryPath, actualRepositoryPath?.TrimEnd(Path.DirectorySeparatorChar));
+            Assert.Equal(temporaryDirectory, actualRepositoryPath?.TrimEnd(Path.DirectorySeparatorChar));
         }
 
         [Fact]
@@ -68,6 +65,22 @@ namespace Grynwald.ChangeLog.Test.Git
         {
             // ARRANGE
             using var temporaryDirectory = new TemporaryDirectory();
+
+            // ACT 
+            var success = RepositoryLocator.TryGetRepositoryPath(temporaryDirectory, out var actualRepositoryPath);
+
+            // ASSERT
+            Assert.False(success);
+            Assert.Null(actualRepositoryPath);
+        }
+
+        [Fact]
+        public async Task TryGetRepositoryPath_fails_when_starting_path_is_a_bare_repository()
+        {
+            // ARRANGE
+            using var temporaryDirectory = new TemporaryDirectory();
+            var git = new GitWrapper(temporaryDirectory, m_TestOutputHelper);
+            await git.InitAsync(createBareRepository: true);
 
             // ACT 
             var success = RepositoryLocator.TryGetRepositoryPath(temporaryDirectory, out var actualRepositoryPath);

--- a/src/ChangeLog.Test/Git/RepositoryLocatorTest.cs
+++ b/src/ChangeLog.Test/Git/RepositoryLocatorTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using Grynwald.ChangeLog.Git;
 using Grynwald.Utilities.IO;
 using Xunit;
@@ -19,13 +20,14 @@ namespace Grynwald.ChangeLog.Test.Git
             m_TestOutputHelper = testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
         }
 
+
         [Fact]
-        public void TryGetRepositoryPath_succeeds_when_starting_path_is_a_git_repository()
+        public async Task TryGetRepositoryPath_succeeds_when_starting_path_is_a_git_repository()
         {
             // ARRANGE
             using var temporaryDirectory = new TemporaryDirectory();
             var git = new GitWrapper(temporaryDirectory, m_TestOutputHelper);
-            git.Init();
+            await git.InitAsync();
 
             var expectedRepositoryPath = Path.Combine(temporaryDirectory, ".git");
 
@@ -43,12 +45,12 @@ namespace Grynwald.ChangeLog.Test.Git
         [InlineData("subdir/dir2/dir3")]
         [InlineData("subdir/dir2/./dir3")]
         [InlineData("subdir/dir2/../dir3")]
-        public void TryGetRepositoryPath_succeeds_when_starting_path_is_a_subdirectory_of_git_repository(string relativePath)
+        public async Task TryGetRepositoryPath_succeeds_when_starting_path_is_a_subdirectory_of_git_repository(string relativePath)
         {
             // ARRANGE
             using var temporaryDirectory = new TemporaryDirectory();
             var git = new GitWrapper(temporaryDirectory, m_TestOutputHelper);
-            git.Init();
+            await git.InitAsync();
 
             var expectedRepositoryPath = Path.Combine(temporaryDirectory, ".git");
             var startingPath = temporaryDirectory.AddSubDirectory(relativePath);

--- a/src/ChangeLog.Test/Grynwald.ChangeLog.Test.csproj
+++ b/src/ChangeLog.Test/Grynwald.ChangeLog.Test.csproj
@@ -25,4 +25,12 @@
     <ProjectReference Include="..\ChangeLog\Grynwald.ChangeLog.csproj" />
   </ItemGroup>
 
+  <!--
+    After build, publish the application into the test's output directory.
+    This is required for running E2E tests where the application is started as a child processs
+  -->
+  <Target Name="PublishApplicationToTestDirectory" AfterTargets="AfterBuild">
+    <MSBuild Projects="..\ChangeLog\Grynwald.ChangeLog.csproj" Targets="Publish" Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration);PublishDir=$(OutputPath)/Grynwald.ChangeLog" />
+  </Target>
+
 </Project>

--- a/src/ChangeLog.Test/Grynwald.ChangeLog.Test.csproj
+++ b/src/ChangeLog.Test/Grynwald.ChangeLog.Test.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="5.4.5" />
+    <PackageReference Include="CliWrap" Version="3.2.4" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.2" />

--- a/src/ChangeLog.Test/TemporaryDirectoryExtensions.cs
+++ b/src/ChangeLog.Test/TemporaryDirectoryExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.IO;
+using Grynwald.Utilities.IO;
+
+namespace Grynwald.ChangeLog.Test
+{
+    internal static class TemporaryDirectoryExtensions
+    {
+        public static string AddSubDirectory(this TemporaryDirectory temporaryDirectory, string relativePath)
+        {
+            if (Path.IsPathRooted(relativePath))
+                throw new ArgumentException("Path must not be rooted", nameof(relativePath));
+
+            var absolutePath = Path.Combine(temporaryDirectory, relativePath);
+            Directory.CreateDirectory(absolutePath);
+
+            return absolutePath;
+        }
+    }
+}

--- a/src/ChangeLog.Test/packages.lock.json
+++ b/src/ChangeLog.Test/packages.lock.json
@@ -15,6 +15,17 @@
           "TextCopy": "4.2.0"
         }
       },
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.2.4, )",
+        "resolved": "3.2.4",
+        "contentHash": "VjAl2kL7lBdm1+KI3uq+Uu98bayf3y3naoSkXoMalbDgyO7xneEdns2G2uQH1Vbxb8MKNg6D4VaC6GDXqJ27MQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
+          "System.Buffers": "4.5.1",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[1.3.0, )",
@@ -612,6 +623,11 @@
         "type": "Transitive",
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -1507,6 +1523,12 @@
           "Microsoft.Win32.Registry": "5.0.0",
           "TextCopy": "4.2.0"
         }
+      },
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.2.4, )",
+        "resolved": "3.2.4",
+        "contentHash": "VjAl2kL7lBdm1+KI3uq+Uu98bayf3y3naoSkXoMalbDgyO7xneEdns2G2uQH1Vbxb8MKNg6D4VaC6GDXqJ27MQ=="
       },
       "coverlet.collector": {
         "type": "Direct",
@@ -3464,6 +3486,12 @@
           "Microsoft.Win32.Registry": "5.0.0",
           "TextCopy": "4.2.0"
         }
+      },
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.2.4, )",
+        "resolved": "3.2.4",
+        "contentHash": "VjAl2kL7lBdm1+KI3uq+Uu98bayf3y3naoSkXoMalbDgyO7xneEdns2G2uQH1Vbxb8MKNg6D4VaC6GDXqJ27MQ=="
       },
       "coverlet.collector": {
         "type": "Direct",

--- a/src/ChangeLog/CommandLineParameters.cs
+++ b/src/ChangeLog/CommandLineParameters.cs
@@ -11,8 +11,7 @@ namespace Grynwald.ChangeLog
         private string? m_OutputPath;
 
 
-        [Option('r', "repository", Required = true, HelpText = "The local path of the git repository to generate a change log for.")]
-        [ConfigurationValue("changelog:repositoryPath")]
+        [Option('r', "repository", Required = false, HelpText = "The local path of the git repository to generate a change log for.")]
         public string RepositoryPath { get; set; } = "";
 
         [Option('c', "configurationFilePath", Required = false, HelpText =

--- a/src/ChangeLog/CommandLineParametersValidator.cs
+++ b/src/ChangeLog/CommandLineParametersValidator.cs
@@ -13,7 +13,7 @@ namespace Grynwald.ChangeLog
         {
             ValidatorOptions.Global.UseCustomDisplayNameResolver();
 
-            RuleFor(x => x.RepositoryPath).NotEmpty();
+            RuleFor(x => x.RepositoryPath).NotWhitespace();
             RuleFor(x => x.RepositoryPath)
                 .Must(Directory.Exists)
                 .UnlessNullOrWhiteSpace()

--- a/src/ChangeLog/Configuration/ChangeLogConfigurationLoader.cs
+++ b/src/ChangeLog/Configuration/ChangeLogConfigurationLoader.cs
@@ -10,23 +10,28 @@ namespace Grynwald.ChangeLog.Configuration
 {
     internal static class ChangeLogConfigurationLoader
     {
-        public static ChangeLogConfiguration GetConfiguration(string configurationFilePath, object? settingsObject = null)
+        public static ChangeLogConfiguration GetConfiguration(string configurationFilePath, params object[] settingsObjects)
         {
             using var defaultSettingsStream = GetDefaultSettingsStream();
             using var configurationFileStream = GetFileStreamOrEmpty(configurationFilePath);
 
             using var preparedStream = PrepareConfigurationFileStream(configurationFileStream);
 
-            return new ConfigurationBuilder()
+
+            var configurationBuilder = new ConfigurationBuilder()
                 .AddJsonStream(defaultSettingsStream)
                 // Use AddJsonStream() because AddJsonFile() assumes the file name
                 // is relative to the ConfigurationBuilder's base directory and does not seem to properly
                 // handle absolute paths
                 .AddJsonStream(preparedStream)
-                .AddEnvironmentVariables()
-                .AddObject(settingsObject)
-                .Load();
+                .AddEnvironmentVariables();
 
+            foreach (var settingsObject in settingsObjects)
+            {
+                configurationBuilder = configurationBuilder.AddObject(settingsObject);
+            }
+
+            return configurationBuilder.Load();
         }
 
         internal static ChangeLogConfiguration GetDefaultConfiguration()

--- a/src/ChangeLog/Git/GitRepository.cs
+++ b/src/ChangeLog/Git/GitRepository.cs
@@ -7,7 +7,7 @@ namespace Grynwald.ChangeLog.Git
 {
     public sealed class GitRepository : IGitRepository
     {
-        private readonly string m_RepositoyPath;
+        private readonly string m_RepositoryPath;
         private readonly Repository m_Repository;
 
         /// <inheritdoc />
@@ -20,14 +20,22 @@ namespace Grynwald.ChangeLog.Git
         /// <summary>
         /// Initializes a new instance of <see cref="GitRepository"/>
         /// </summary>
-        /// <param name="repositoyPath">The local path of the git repository.</param>
-        public GitRepository(string repositoyPath)
+        /// <param name="repositoryPath">The local path of the git repository.</param>
+        public GitRepository(string repositoryPath)
         {
-            if (String.IsNullOrWhiteSpace(repositoyPath))
-                throw new ArgumentException("Value must not be null or whitespace.", nameof(repositoyPath));
+            if (String.IsNullOrWhiteSpace(repositoryPath))
+                throw new ArgumentException("Value must not be null or whitespace.", nameof(repositoryPath));
 
-            m_RepositoyPath = repositoyPath;
-            m_Repository = new Repository(m_RepositoyPath);
+            m_RepositoryPath = repositoryPath;
+
+            try
+            {
+                m_Repository = new Repository(m_RepositoryPath);
+            }
+            catch (LibGit2Sharp.RepositoryNotFoundException ex)
+            {
+                throw new RepositoryNotFoundException($"Directory '{repositoryPath}' is not a git repository", ex);
+            }
         }
 
 

--- a/src/ChangeLog/Git/RepositoryLocator.cs
+++ b/src/ChangeLog/Git/RepositoryLocator.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using LibGit2Sharp;
+
+namespace Grynwald.ChangeLog.Git
+{
+    /// <summary>
+    /// Helper class to find to locate git repositories
+    /// </summary>
+    public sealed class RepositoryLocator
+    {
+        /// <summary>
+        /// Attempts to get the root directory of a git repository stating from <paramref name="startingPath"/>.
+        /// </summary>
+        /// <remarks>
+        /// Searches <paramref name="startingPath"/> and any of its parent directories and checks if the directory is a valid git repository.
+        /// </remarks>
+        /// <param name="startingPath">The directory to start the search for a git repository.</param>
+        /// <param name="repositoryPath">On success, contains the root path of the git repository</param>
+        /// <returns>Returns <c>true</c> if a git repository was found, otherwise returns <c>false</c>.</returns>
+        public static bool TryGetRepositoryPath(string startingPath, [NotNullWhen(true)] out string? repositoryPath)
+        {
+            var path = Repository.Discover(startingPath);
+            if (String.IsNullOrEmpty(path))
+            {
+                repositoryPath = default;
+                return false;
+            }
+            else
+            {
+                repositoryPath = path;
+                return true;
+            }
+        }
+    }
+}

--- a/src/ChangeLog/Git/RepositoryLocator.cs
+++ b/src/ChangeLog/Git/RepositoryLocator.cs
@@ -10,7 +10,7 @@ namespace Grynwald.ChangeLog.Git
     public sealed class RepositoryLocator
     {
         /// <summary>
-        /// Attempts to get the root directory of a git repository stating from <paramref name="startingPath"/>.
+        /// Attempts to get working directory of a git repository stating from <paramref name="startingPath"/>.
         /// </summary>
         /// <remarks>
         /// Searches <paramref name="startingPath"/> and any of its parent directories and checks if the directory is a valid git repository.
@@ -21,16 +21,21 @@ namespace Grynwald.ChangeLog.Git
         public static bool TryGetRepositoryPath(string startingPath, [NotNullWhen(true)] out string? repositoryPath)
         {
             var path = Repository.Discover(startingPath);
-            if (String.IsNullOrEmpty(path))
+
+            if (!String.IsNullOrEmpty(path))
             {
-                repositoryPath = default;
-                return false;
+                using var repo = new Repository(path);
+                var workingDirectory = repo.Info.WorkingDirectory;
+
+                if (!String.IsNullOrEmpty(workingDirectory))
+                {
+                    repositoryPath = workingDirectory;
+                    return true;
+                }
             }
-            else
-            {
-                repositoryPath = path;
-                return true;
-            }
+
+            repositoryPath = default;
+            return false;
         }
     }
 }

--- a/src/ChangeLog/Git/RepositoryNotFoundException.cs
+++ b/src/ChangeLog/Git/RepositoryNotFoundException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Grynwald.ChangeLog.Git
+{
+    public class RepositoryNotFoundException : Exception
+    {
+        public RepositoryNotFoundException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Description

Make it optional to specify the repository directoy as command line parameter.

When no repository directory is specified, try to open the current directory or any of its parent directories as git repository.

This will make changelog behave similar to git itself and allow it to be launched in any directory within a repository without specifying the repository path.


### TODOs

- [x] Add tests for `Program.cs` to verify current behaviour
- [x] Make `repository` parameter optional, locate repo from current directory
- [x] Update documentation