### PR TITLE
 test: Improve logging in E2E tests in an attempt to track down sporadically failing test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,6 +141,17 @@ jobs:
       publishTestResults: true
       projects: $(solutionPath)
       arguments: '--configuration $(configuration) --no-build --collect:"XPlat Code Coverage"'
+
+  - powershell: |
+      $trxFiles = Get-ChildItem -Path "$(Agent.TempDirectory)" -Filter "*.trx" -File -Recurse
+      $trxFileCount = ($trxFiles | Measure-Object).Count
+      Write-Host "Found $trxFileCount trx files in '$(Agent.TempDirectory)'"
+      foreach($trxFile in $trxFiles) {
+        Write-Host "Publishing Artifact '$($trxFile.FullName)'"
+        Write-Host "##vso[artifact.upload artifactname=TestResults]$($trxFile.FullName)"
+      }
+    displayName: Publish test results
+
   # The PublishCodeCoverageResults task only supports publishing a single coverage result file,
   # so the results are merged into a single cobertura file using "ReportGenerator"
   # The dotnet test task redirects test results to $(Agent.TempDirectory) so coverage reports will be written there, too

--- a/src/ChangeLog.Test/CommandExtensions.cs
+++ b/src/ChangeLog.Test/CommandExtensions.cs
@@ -8,7 +8,7 @@ namespace Grynwald.ChangeLog.Test
     /// <summary>
     /// Extension methods for <see cref="CliWrap.Command"/>
     /// </summary>
-    public static class CommandExtentsions
+    public static class CommandExtensions
     {
         public static Command AddTestOutputPipe(this Command command, ITestOutputHelper testOutputHelper)
         {
@@ -23,13 +23,17 @@ namespace Grynwald.ChangeLog.Test
                     PipeTarget.ToDelegate(testOutputHelper.WriteLine)));
         }
 
-        public static async Task<BufferedCommandResult> ExecuteBufferedWithTestOutputAsync(this Command command, ITestOutputHelper testOutputHelper)
+        public static async Task<BufferedCommandResult> ExecuteBufferedWithTestOutputAsync(this Command command, ITestOutputHelper testOutputHelper, string? commandId = null)
         {
             command = command.AddTestOutputPipe(testOutputHelper);
 
             testOutputHelper.WriteLine("------------------------------------------------------------");
             testOutputHelper.WriteLine($"BEGIN Command '{command.TargetFilePath} {command.Arguments}'");
             testOutputHelper.WriteLine($"Working directory: '{command.WorkingDirPath}'");
+            if (commandId is not null)
+            {
+                testOutputHelper.WriteLine($"Command Id: '{commandId}'");
+            }
             testOutputHelper.WriteLine("------------------------------------------------------------");
 
             var result = await command.ExecuteBufferedAsync();

--- a/src/ChangeLog.Test/E2E/E2ETests.cs
+++ b/src/ChangeLog.Test/E2E/E2ETests.cs
@@ -31,7 +31,10 @@ namespace Grynwald.ChangeLog.Test.E2E
             var applicationVersion = typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
             // ACT 
-            var result = await RunApplicationAsync(new[] { "--help" });
+            var result = await RunApplicationAsync(
+                args: new[] { "--help" },
+                commandId: nameof(Requesting_help_succeeds)
+            );
 
             // ASSERT
             Assert.Equal(0, result.ExitCode);
@@ -56,7 +59,10 @@ namespace Grynwald.ChangeLog.Test.E2E
             var expectedVersion = typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
             // ACT 
-            var result = await RunApplicationAsync(new[] { "--version" });
+            var result = await RunApplicationAsync(
+                args: new[] { "--version" },
+                commandId: nameof(Requesting_version_succeeds)
+            );
 
             // ASSERT
             Assert.Equal(0, result.ExitCode);
@@ -92,7 +98,10 @@ namespace Grynwald.ChangeLog.Test.E2E
                 "");
 
             // ACT 
-            var result = await RunApplicationAsync(new[] { "--repository", temporaryDirectory });
+            var result = await RunApplicationAsync(
+                args: new[] { "--repository", temporaryDirectory },
+                commandId: nameof(Change_log_is_generated_from_the_specified_repository)
+            );
 
             // ASSERT
             Assert.Equal(0, result.ExitCode);
@@ -122,7 +131,9 @@ namespace Grynwald.ChangeLog.Test.E2E
             // ACT 
             var result = await RunApplicationAsync(
                 args: new[] { "--repository", "repo" },
-                workingDirectory: temporaryDirectory);
+                workingDirectory: temporaryDirectory,
+                commandId: nameof(Repository_path_can_be_passed_as_relative_path)
+            );
 
             // ASSERT
             Assert.Equal(0, result.ExitCode);
@@ -161,7 +172,11 @@ namespace Grynwald.ChangeLog.Test.E2E
                 "");
 
             // ACT 
-            var result = await RunApplicationAsync(args: Array.Empty<string>(), workingDirectory: workingDirectory);
+            var result = await RunApplicationAsync(
+                args: new[] { "--verbose" },
+                workingDirectory: workingDirectory,
+                commandId: $"{nameof(When_no_repository_is_specified_the_repository_is_located_from_the_current_directory)}(\"{relativeWorkingDirectoryPath}\")"
+            );
 
             // ASSERT
             Assert.Equal(0, result.ExitCode);
@@ -176,7 +191,10 @@ namespace Grynwald.ChangeLog.Test.E2E
             using var temporaryDirectory = new TemporaryDirectory();
 
             // ACT 
-            var result = await RunApplicationAsync(new[] { "--repository", temporaryDirectory });
+            var result = await RunApplicationAsync(
+                args: new[] { "--repository", temporaryDirectory },
+                commandId: nameof(When_specified_repository_path_is_not_a_git_repository_an_error_is_shown)
+            );
 
             // ASSERT
             Assert.Equal(1, result.ExitCode);
@@ -193,7 +211,9 @@ namespace Grynwald.ChangeLog.Test.E2E
             // ACT 
             var result = await RunApplicationAsync(
                 args: Array.Empty<string>(),
-                workingDirectory: temporaryDirectory);
+                workingDirectory: temporaryDirectory,
+                commandId: nameof(When_started_outside_of_a_git_repository_and_no_repository_path_is_specified_an_error_is_shown)
+            );
 
             // ASSERT
             Assert.Equal(1, result.ExitCode);
@@ -205,7 +225,7 @@ namespace Grynwald.ChangeLog.Test.E2E
         /// <summary>
         /// Runs changelog with the specified command line parameters
         /// </summary>
-        private async Task<BufferedCommandResult> RunApplicationAsync(string[] args, string? workingDirectory = null)
+        private async Task<BufferedCommandResult> RunApplicationAsync(string[] args, string? workingDirectory = null, string? commandId = null)
         {
             var applicationAssembly = typeof(Program).Assembly;
 
@@ -239,7 +259,7 @@ namespace Grynwald.ChangeLog.Test.E2E
                 command = command.WithWorkingDirectory(workingDirectory);
             }
 
-            var result = await command.ExecuteBufferedWithTestOutputAsync(m_TestOutputHelper);
+            var result = await command.ExecuteBufferedWithTestOutputAsync(m_TestOutputHelper, commandId: commandId);
 
             return result;
         }

--- a/src/ChangeLog/Tasks/RenderTemplateTask.cs
+++ b/src/ChangeLog/Tasks/RenderTemplateTask.cs
@@ -35,6 +35,7 @@ namespace Grynwald.ChangeLog.Tasks
             Directory.CreateDirectory(outputDirectory!);
 
             m_Logger.LogInformation($"Saving changelog to '{outputPath}'");
+            m_Logger.LogDebug($"Using template '{m_Template.GetType().Name}'");
             try
             {
                 m_Template.SaveChangeLog(changeLog, outputPath);


### PR DESCRIPTION
Test case `E2ETests.When_no_repository_is_specified_the_repository_is_located_from_the_current_directory` sporadically fails when running in CI.

