### PR TITLE
fix: Fix GitLab authentication when access token contains a prefix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/GitLabApiClient"]
+	path = deps/GitLabApiClient
+	url = https://github.com/ap0llo/GitLabApiClient.git

--- a/ChangeLog.sln
+++ b/ChangeLog.sln
@@ -22,6 +22,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "docs", "utilities\docs\docs
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "schema", "utilities\schema\schema.csproj", "{60DD3AA4-7B2D-419A-87B5-06E6BC419F53}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "deps", "deps", "{54A2E9A3-22AE-4966-9B99-04037A4B7B3D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitLabApiClient", "deps\GitLabApiClient\src\GitLabApiClient\GitLabApiClient.csproj", "{35BBDAE8-D8B6-4D5C-9FE2-E32D84359476}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +48,10 @@ Global
 		{60DD3AA4-7B2D-419A-87B5-06E6BC419F53}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{60DD3AA4-7B2D-419A-87B5-06E6BC419F53}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{60DD3AA4-7B2D-419A-87B5-06E6BC419F53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35BBDAE8-D8B6-4D5C-9FE2-E32D84359476}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35BBDAE8-D8B6-4D5C-9FE2-E32D84359476}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35BBDAE8-D8B6-4D5C-9FE2-E32D84359476}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35BBDAE8-D8B6-4D5C-9FE2-E32D84359476}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +61,7 @@ Global
 		{71F3394B-0EFE-4F4E-BF2F-AA188EE69C69} = {6F9277E0-FE69-423E-9562-17AD4685338C}
 		{87DD8806-172C-4C69-B9DD-5B1D593DB058} = {06933B81-2529-4A00-AF92-72995E60EF1F}
 		{60DD3AA4-7B2D-419A-87B5-06E6BC419F53} = {06933B81-2529-4A00-AF92-72995E60EF1F}
+		{35BBDAE8-D8B6-4D5C-9FE2-E32D84359476} = {54A2E9A3-22AE-4966-9B99-04037A4B7B3D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {87929660-5CD6-4938-983E-81B0B0DE86D6}

--- a/deps/Directory.Build.props
+++ b/deps/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+
+
+</Project>

--- a/src/ChangeLog.Test/packages.lock.json
+++ b/src/ChangeLog.Test/packages.lock.json
@@ -190,14 +190,6 @@
         "resolved": "10.2.3",
         "contentHash": "R2w/E6jgg9RPSlg7JQSTHg6AWDwlOXARaV4ZUKrPJ1gi1e+oaBEcomxmo29j9BLZivkyQhOpAboJ9nKZS4/xYA=="
       },
-      "GitLabApiClient": {
-        "type": "Transitive",
-        "resolved": "1.7.0",
-        "contentHash": "su6z8EdghQpk/3UDc5OzsGnOOBMNpTu0G2Lqjt1/IBcDkFvelFKS645h4fNrI2Awvni2DIl//Z/A3HczY9Kd9w==",
-        "dependencies": {
-          "Newtonsoft.Json": "12.0.3"
-        }
-      },
       "Grynwald.Utilities": {
         "type": "Transitive",
         "resolved": "1.6.11-pre",
@@ -1501,13 +1493,19 @@
         "resolved": "0.11.0",
         "contentHash": "eNHy6n/UCuQKtqCVw2XIw7L9g1/5vEFuMJ8aLM6tXLxh+vAFajwW1+oFAL65t31YNWro0uLDCez5mGsamC73QA=="
       },
+      "gitlabapiclient": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.3"
+        }
+      },
       "grynwald.changelog": {
         "type": "Project",
         "dependencies": {
           "Autofac": "6.2.0",
           "CommandLineParser": "2.8.0",
           "FluentValidation": "10.2.3",
-          "GitLabApiClient": "1.7.0",
+          "GitLabApiClient": "1.0.0",
           "Grynwald.Utilities": "1.6.11-pre",
           "Grynwald.Utilities.Configuration": "1.6.11-pre",
           "Grynwald.Utilities.Logging": "1.6.11-pre",
@@ -1694,14 +1692,6 @@
         "type": "Transitive",
         "resolved": "10.2.3",
         "contentHash": "R2w/E6jgg9RPSlg7JQSTHg6AWDwlOXARaV4ZUKrPJ1gi1e+oaBEcomxmo29j9BLZivkyQhOpAboJ9nKZS4/xYA=="
-      },
-      "GitLabApiClient": {
-        "type": "Transitive",
-        "resolved": "1.7.0",
-        "contentHash": "su6z8EdghQpk/3UDc5OzsGnOOBMNpTu0G2Lqjt1/IBcDkFvelFKS645h4fNrI2Awvni2DIl//Z/A3HczY9Kd9w==",
-        "dependencies": {
-          "Newtonsoft.Json": "12.0.3"
-        }
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -3492,13 +3482,19 @@
         "resolved": "0.11.0",
         "contentHash": "eNHy6n/UCuQKtqCVw2XIw7L9g1/5vEFuMJ8aLM6tXLxh+vAFajwW1+oFAL65t31YNWro0uLDCez5mGsamC73QA=="
       },
+      "gitlabapiclient": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.3"
+        }
+      },
       "grynwald.changelog": {
         "type": "Project",
         "dependencies": {
           "Autofac": "6.2.0",
           "CommandLineParser": "2.8.0",
           "FluentValidation": "10.2.3",
-          "GitLabApiClient": "1.7.0",
+          "GitLabApiClient": "1.0.0",
           "Grynwald.Utilities": "1.6.11-pre",
           "Grynwald.Utilities.Configuration": "1.6.11-pre",
           "Grynwald.Utilities.Logging": "1.6.11-pre",
@@ -3685,14 +3681,6 @@
         "type": "Transitive",
         "resolved": "10.2.3",
         "contentHash": "R2w/E6jgg9RPSlg7JQSTHg6AWDwlOXARaV4ZUKrPJ1gi1e+oaBEcomxmo29j9BLZivkyQhOpAboJ9nKZS4/xYA=="
-      },
-      "GitLabApiClient": {
-        "type": "Transitive",
-        "resolved": "1.7.0",
-        "contentHash": "su6z8EdghQpk/3UDc5OzsGnOOBMNpTu0G2Lqjt1/IBcDkFvelFKS645h4fNrI2Awvni2DIl//Z/A3HczY9Kd9w==",
-        "dependencies": {
-          "Newtonsoft.Json": "12.0.3"
-        }
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -5462,13 +5450,19 @@
         "resolved": "0.11.0",
         "contentHash": "eNHy6n/UCuQKtqCVw2XIw7L9g1/5vEFuMJ8aLM6tXLxh+vAFajwW1+oFAL65t31YNWro0uLDCez5mGsamC73QA=="
       },
+      "gitlabapiclient": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.3"
+        }
+      },
       "grynwald.changelog": {
         "type": "Project",
         "dependencies": {
           "Autofac": "6.2.0",
           "CommandLineParser": "2.8.0",
           "FluentValidation": "10.2.3",
-          "GitLabApiClient": "1.7.0",
+          "GitLabApiClient": "1.0.0",
           "Grynwald.Utilities": "1.6.11-pre",
           "Grynwald.Utilities.Configuration": "1.6.11-pre",
           "Grynwald.Utilities.Logging": "1.6.11-pre",

--- a/src/ChangeLog/Grynwald.ChangeLog.csproj
+++ b/src/ChangeLog/Grynwald.ChangeLog.csproj
@@ -48,9 +48,13 @@
     <PackageReference Include="NuGet.Versioning" Version="5.9.1" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Autofac" Version="6.2.0" />
-    <PackageReference Include="GitLabApiClient" Version="1.7.0" />
     <PackageReference Include="Scriban" Version="4.0.1" />  
     <PackageReference Include="Zio" Version="0.11.0" />
+  </ItemGroup>
+    
+    
+  <ItemGroup>
+    <ProjectReference Include="..\..\deps\GitLabApiClient\src\GitLabApiClient\GitLabApiClient.csproj" />
   </ItemGroup>
 
   <!-- Auto-Generated command line help -->

--- a/src/ChangeLog/packages.lock.json
+++ b/src/ChangeLog/packages.lock.json
@@ -24,15 +24,6 @@
         "resolved": "10.2.3",
         "contentHash": "R2w/E6jgg9RPSlg7JQSTHg6AWDwlOXARaV4ZUKrPJ1gi1e+oaBEcomxmo29j9BLZivkyQhOpAboJ9nKZS4/xYA=="
       },
-      "GitLabApiClient": {
-        "type": "Direct",
-        "requested": "[1.7.0, )",
-        "resolved": "1.7.0",
-        "contentHash": "su6z8EdghQpk/3UDc5OzsGnOOBMNpTu0G2Lqjt1/IBcDkFvelFKS645h4fNrI2Awvni2DIl//Z/A3HczY9Kd9w==",
-        "dependencies": {
-          "Newtonsoft.Json": "12.0.3"
-        }
-      },
       "Grynwald.MdDocs.MSBuild": {
         "type": "Direct",
         "requested": "[0.4.178, )",
@@ -363,6 +354,12 @@
         "type": "Transitive",
         "resolved": "4.5.0",
         "contentHash": "csAJe24tWCOTO/rXoJAuBGuOq7ZdHY60XtC6b/hNMHT9tuX+2J9HK7nciLEtNvnrRLMxBACLXO3R4y5+kCduMA=="
+      },
+      "gitlabapiclient": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.3"
+        }
       }
     },
     ".NETCoreApp,Version=v3.1": {
@@ -386,15 +383,6 @@
         "requested": "[10.2.3, )",
         "resolved": "10.2.3",
         "contentHash": "R2w/E6jgg9RPSlg7JQSTHg6AWDwlOXARaV4ZUKrPJ1gi1e+oaBEcomxmo29j9BLZivkyQhOpAboJ9nKZS4/xYA=="
-      },
-      "GitLabApiClient": {
-        "type": "Direct",
-        "requested": "[1.7.0, )",
-        "resolved": "1.7.0",
-        "contentHash": "su6z8EdghQpk/3UDc5OzsGnOOBMNpTu0G2Lqjt1/IBcDkFvelFKS645h4fNrI2Awvni2DIl//Z/A3HczY9Kd9w==",
-        "dependencies": {
-          "Newtonsoft.Json": "12.0.3"
-        }
       },
       "Grynwald.MdDocs.MSBuild": {
         "type": "Direct",
@@ -648,6 +636,12 @@
         "type": "Transitive",
         "resolved": "4.5.0",
         "contentHash": "csAJe24tWCOTO/rXoJAuBGuOq7ZdHY60XtC6b/hNMHT9tuX+2J9HK7nciLEtNvnrRLMxBACLXO3R4y5+kCduMA=="
+      },
+      "gitlabapiclient": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.3"
+        }
       }
     },
     ".NETCoreApp,Version=v5.0": {
@@ -671,15 +665,6 @@
         "requested": "[10.2.3, )",
         "resolved": "10.2.3",
         "contentHash": "R2w/E6jgg9RPSlg7JQSTHg6AWDwlOXARaV4ZUKrPJ1gi1e+oaBEcomxmo29j9BLZivkyQhOpAboJ9nKZS4/xYA=="
-      },
-      "GitLabApiClient": {
-        "type": "Direct",
-        "requested": "[1.7.0, )",
-        "resolved": "1.7.0",
-        "contentHash": "su6z8EdghQpk/3UDc5OzsGnOOBMNpTu0G2Lqjt1/IBcDkFvelFKS645h4fNrI2Awvni2DIl//Z/A3HczY9Kd9w==",
-        "dependencies": {
-          "Newtonsoft.Json": "12.0.3"
-        }
       },
       "Grynwald.MdDocs.MSBuild": {
         "type": "Direct",
@@ -912,6 +897,12 @@
         "type": "Transitive",
         "resolved": "4.7.1",
         "contentHash": "j81Lovt90PDAq8kLpaJfJKV/rWdWuEk6jfV+MBkee33vzYLEUsy4gXK8laa9V2nZlLM9VM9yA/OOQxxPEJKAMw=="
+      },
+      "gitlabapiclient": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.3"
+        }
       }
     }
   }

--- a/utilities/docs/packages.lock.json
+++ b/utilities/docs/packages.lock.json
@@ -64,14 +64,6 @@
         "resolved": "10.2.3",
         "contentHash": "R2w/E6jgg9RPSlg7JQSTHg6AWDwlOXARaV4ZUKrPJ1gi1e+oaBEcomxmo29j9BLZivkyQhOpAboJ9nKZS4/xYA=="
       },
-      "GitLabApiClient": {
-        "type": "Transitive",
-        "resolved": "1.7.0",
-        "contentHash": "su6z8EdghQpk/3UDc5OzsGnOOBMNpTu0G2Lqjt1/IBcDkFvelFKS645h4fNrI2Awvni2DIl//Z/A3HczY9Kd9w==",
-        "dependencies": {
-          "Newtonsoft.Json": "12.0.3"
-        }
-      },
       "Grynwald.Utilities": {
         "type": "Transitive",
         "resolved": "1.6.11-pre",
@@ -264,13 +256,19 @@
         "resolved": "0.11.0",
         "contentHash": "eNHy6n/UCuQKtqCVw2XIw7L9g1/5vEFuMJ8aLM6tXLxh+vAFajwW1+oFAL65t31YNWro0uLDCez5mGsamC73QA=="
       },
+      "gitlabapiclient": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.3"
+        }
+      },
       "grynwald.changelog": {
         "type": "Project",
         "dependencies": {
           "Autofac": "6.2.0",
           "CommandLineParser": "2.8.0",
           "FluentValidation": "10.2.3",
-          "GitLabApiClient": "1.7.0",
+          "GitLabApiClient": "1.0.0",
           "Grynwald.Utilities": "1.6.11-pre",
           "Grynwald.Utilities.Configuration": "1.6.11-pre",
           "Grynwald.Utilities.Logging": "1.6.11-pre",

--- a/utilities/schema/packages.lock.json
+++ b/utilities/schema/packages.lock.json
@@ -85,14 +85,6 @@
         "resolved": "10.2.3",
         "contentHash": "R2w/E6jgg9RPSlg7JQSTHg6AWDwlOXARaV4ZUKrPJ1gi1e+oaBEcomxmo29j9BLZivkyQhOpAboJ9nKZS4/xYA=="
       },
-      "GitLabApiClient": {
-        "type": "Transitive",
-        "resolved": "1.7.0",
-        "contentHash": "su6z8EdghQpk/3UDc5OzsGnOOBMNpTu0G2Lqjt1/IBcDkFvelFKS645h4fNrI2Awvni2DIl//Z/A3HczY9Kd9w==",
-        "dependencies": {
-          "Newtonsoft.Json": "12.0.3"
-        }
-      },
       "Grynwald.Utilities": {
         "type": "Transitive",
         "resolved": "1.6.11-pre",
@@ -1254,13 +1246,19 @@
         "resolved": "0.11.0",
         "contentHash": "eNHy6n/UCuQKtqCVw2XIw7L9g1/5vEFuMJ8aLM6tXLxh+vAFajwW1+oFAL65t31YNWro0uLDCez5mGsamC73QA=="
       },
+      "gitlabapiclient": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.3"
+        }
+      },
       "grynwald.changelog": {
         "type": "Project",
         "dependencies": {
           "Autofac": "6.2.0",
           "CommandLineParser": "2.8.0",
           "FluentValidation": "10.2.3",
-          "GitLabApiClient": "1.7.0",
+          "GitLabApiClient": "1.0.0",
           "Grynwald.Utilities": "1.6.11-pre",
           "Grynwald.Utilities.Configuration": "1.6.11-pre",
           "Grynwald.Utilities.Logging": "1.6.11-pre",


### PR DESCRIPTION
Replace GitLabApiClient package reference with a git submodule. Submodule pulls in a fork of GitLabApiClient that includes a fix to make authentication with prefixed GitLab access tokens work.


See-Also: nmklotas/GitLabApiClient#207
See-Also: nmklotas/GitLabApiClient#204
