### PR TITLE
[WIP]feat(github): Add option to override a commit's message through commit comments

### DIFF
--- a/src/ChangeLog.Test/Model/SingleVersionChangeLogTest.cs
+++ b/src/ChangeLog.Test/Model/SingleVersionChangeLogTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Grynwald.ChangeLog.ConventionalCommits;
+using Grynwald.ChangeLog.Git;
 using Grynwald.ChangeLog.Model;
 using Xunit;
 
@@ -74,10 +75,33 @@ namespace Grynwald.ChangeLog.Test.Model
         }
 
         [Fact]
-        public void Add_checks_argument_for_null()
+        public void Add_checks_ChangeLogEntry_argument_for_null()
         {
             var sut = GetSingleVersionChangeLog("1.2.3");
-            Assert.Throws<ArgumentNullException>(() => sut.Add(null!));
+            Assert.Throws<ArgumentNullException>(() => sut.Add((ChangeLogEntry)null!));
+        }
+
+        [Fact]
+        public void Add_checks_GitCommit_argument_for_null()
+        {
+            var sut = GetSingleVersionChangeLog("1.2.3");
+            Assert.Throws<ArgumentNullException>(() => sut.Add((GitCommit)null!));
+        }
+
+        [Fact]
+        public void Add_throws_InvalidOperationException_when_commit_already_exists()
+        {
+            // ARRANGE
+            var commit = GetGitCommit(TestGitIds.Id1);
+            var sut = GetSingleVersionChangeLog("1.2.3");
+            sut.Add(commit);
+
+            // ACT 
+            var ex = Record.Exception(() => sut.Add(commit));
+
+            // ASSERT
+            Assert.IsType<InvalidOperationException>(ex);
+            Assert.Contains("already contains commit", ex.Message);
         }
 
         [Fact]

--- a/src/ChangeLog.Test/Tasks/LoadCommitsTaskTest.cs
+++ b/src/ChangeLog.Test/Tasks/LoadCommitsTaskTest.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Threading.Tasks;
+using Grynwald.ChangeLog.Git;
+using Grynwald.ChangeLog.Model;
+using Grynwald.ChangeLog.Pipeline;
+using Grynwald.ChangeLog.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Grynwald.ChangeLog.Test.Tasks
+{
+    /// <summary>
+    /// Unit tests for <see cref="LoadCommitsTask"/>
+    /// </summary>
+    public class LoadCommitsTaskTest : TestBase
+    {
+        private readonly ILogger<LoadCommitsTask> m_Logger;
+
+
+        public LoadCommitsTaskTest(ITestOutputHelper testOutputHelper)
+        {
+            m_Logger = new XunitLogger<LoadCommitsTask>(testOutputHelper);
+        }
+
+
+        [Fact]
+        public void Logger_must_not_be_null()
+        {
+            // ARRANGE
+
+            // ACT 
+            var ex = Record.Exception(() => new LoadCommitsTask(logger: null!, repository: Mock.Of<IGitRepository>()));
+
+            // ASSERT
+            var argumentNullException = Assert.IsType<ArgumentNullException>(ex);
+            Assert.Equal("logger", argumentNullException.ParamName);
+        }
+
+        [Fact]
+        public void Repository_must_not_be_null()
+        {
+            // ARRANGE
+
+            // ACT 
+            var ex = Record.Exception(() => new LoadCommitsTask(logger: m_Logger, repository: null!));
+
+            // ASSERT
+            var argumentNullException = Assert.IsType<ArgumentNullException>(ex);
+            Assert.Equal("repository", argumentNullException.ParamName);
+        }
+
+        [Fact]
+        public async Task Run_does_nothing_for_empty_changelog()
+        {
+            // ARRANGE
+            var repo = Mock.Of<IGitRepository>(MockBehavior.Strict);
+
+            var sut = new LoadCommitsTask(m_Logger, repo);
+
+            // ACT
+            var changelog = new ApplicationChangeLog();
+            var result = await sut.RunAsync(changelog);
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Skipped, result);
+        }
+
+        [Fact]
+        public async Task Run_adds_all_commits_if_no_previous_version_exists()
+        {
+            // ARRANGE
+            var repo = new Mock<IGitRepository>(MockBehavior.Strict);
+            repo
+                .Setup(x => x.GetCommits(null, It.IsAny<GitId>()))
+                .Returns(new[]
+                {
+                    GetGitCommit(TestGitIds.Id1, "Commit 1"),
+                    GetGitCommit(TestGitIds.Id2, "Commit 2")
+                });
+
+            var sut = new LoadCommitsTask(m_Logger, repo.Object);
+
+            var versionChangeLog = GetSingleVersionChangeLog("1.2.3", TestGitIds.Id1);
+            var changelog = new ApplicationChangeLog() { versionChangeLog };
+
+            // ACT
+            var result = await sut.RunAsync(changelog);
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+
+            repo.Verify(x => x.GetCommits(It.IsAny<GitId?>(), It.IsAny<GitId>()), Times.Once);
+
+            Assert.NotNull(versionChangeLog.AllCommits);
+            Assert.Equal(2, versionChangeLog.AllCommits.Count);
+            Assert.Contains(versionChangeLog.AllCommits, c => c.Id == TestGitIds.Id1);
+            Assert.Contains(versionChangeLog.AllCommits, c => c.Id == TestGitIds.Id2);
+        }
+
+        [Fact]
+        public async Task Run_adds_the_expected_commits_if_a_previous_version_exists()
+        {
+            // ARRANGE
+            var repo = new Mock<IGitRepository>(MockBehavior.Strict);
+            repo
+                .Setup(x => x.GetCommits(null, TestGitIds.Id1))
+                .Returns(Array.Empty<GitCommit>());
+
+            repo
+                .Setup(x => x.GetCommits(TestGitIds.Id1, TestGitIds.Id2))
+                .Returns(new[]
+                {
+                    GetGitCommit(TestGitIds.Id1, "Commit 1" ),
+                    GetGitCommit(TestGitIds.Id2, "Commit 2" ),
+                });
+
+            var sut = new LoadCommitsTask(m_Logger, repo.Object);
+
+            var versionChangeLog1 = GetSingleVersionChangeLog("1.2.3", TestGitIds.Id1);
+
+            var versionChangeLog2 = GetSingleVersionChangeLog("2.4.5", TestGitIds.Id2);
+
+            var changelog = new ApplicationChangeLog()
+            {
+                versionChangeLog1, versionChangeLog2
+            };
+
+            // ACT
+            var result = await sut.RunAsync(changelog);
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+
+            repo.Verify(x => x.GetCommits(null, It.IsAny<GitId>()), Times.Once);
+            repo.Verify(x => x.GetCommits(It.IsAny<GitId>(), It.IsAny<GitId>()), Times.Once);
+
+            Assert.NotNull(versionChangeLog1.AllCommits);
+            Assert.Empty(versionChangeLog1.AllCommits);
+
+            Assert.NotNull(versionChangeLog2.AllCommits);
+            Assert.Equal(2, versionChangeLog2.AllCommits.Count);
+            Assert.Contains(versionChangeLog2.AllCommits, c => c.Id == TestGitIds.Id1);
+            Assert.Contains(versionChangeLog2.AllCommits, c => c.Id == TestGitIds.Id2);
+        }
+    }
+}

--- a/src/ChangeLog/Model/SingleVersionChangeLog.cs
+++ b/src/ChangeLog/Model/SingleVersionChangeLog.cs
@@ -2,17 +2,22 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Grynwald.ChangeLog.Git;
+using Grynwald.Utilities.Collections;
 
 namespace Grynwald.ChangeLog.Model
 {
     public sealed class SingleVersionChangeLog : IEnumerable<ChangeLogEntry>
     {
-        private readonly List<ChangeLogEntry> m_Entries = new List<ChangeLogEntry>();
+        private readonly List<ChangeLogEntry> m_AllEntries = new List<ChangeLogEntry>();
+        private readonly Dictionary<GitId, GitCommit> m_AllCommits = new Dictionary<GitId, GitCommit>();
 
 
         public VersionInfo Version { get; }
 
-        public IEnumerable<ChangeLogEntry> AllEntries => m_Entries.OrderBy(x => x.Date);
+        public IEnumerable<ChangeLogEntry> AllEntries => m_AllEntries.OrderBy(x => x.Date);
+
+        public IReadOnlyCollection<GitCommit> AllCommits { get; }
 
         /// <summary>
         /// Gets all change log entries that contain a breaking change.
@@ -26,6 +31,7 @@ namespace Grynwald.ChangeLog.Model
         public SingleVersionChangeLog(VersionInfo version)
         {
             Version = version ?? throw new ArgumentNullException(nameof(version));
+            AllCommits = ReadOnlyCollectionAdapter.Create(m_AllCommits.Values);
         }
 
 
@@ -34,7 +40,7 @@ namespace Grynwald.ChangeLog.Model
             if (entry is null)
                 throw new ArgumentNullException(nameof(entry));
 
-            m_Entries.Add(entry);
+            m_AllEntries.Add(entry);
         }
 
         public void Remove(ChangeLogEntry entry)
@@ -42,7 +48,18 @@ namespace Grynwald.ChangeLog.Model
             if (entry is null)
                 throw new ArgumentNullException(nameof(entry));
 
-            m_Entries.Remove(entry);
+            m_AllEntries.Remove(entry);
+        }
+
+        public void Add(GitCommit commit)
+        {
+            if (commit is null)
+                throw new ArgumentNullException(nameof(commit));
+
+            if (m_AllCommits.ContainsKey(commit.Id))
+                throw new InvalidOperationException($"Changelog already contains commit '{commit.Id}'");
+
+            m_AllCommits.Add(commit.Id, commit);
         }
 
         public IEnumerator<ChangeLogEntry> GetEnumerator() => AllEntries.GetEnumerator();

--- a/src/ChangeLog/Program.cs
+++ b/src/ChangeLog/Program.cs
@@ -99,6 +99,7 @@ namespace Grynwald.ChangeLog
 
                 containerBuilder.RegisterType<LoadCurrentVersionTask>();
                 containerBuilder.RegisterType<LoadVersionsFromTagsTask>();
+                containerBuilder.RegisterType<LoadCommitsTask>();
                 containerBuilder.RegisterType<ParseCommitsTask>();
                 containerBuilder.RegisterType<ParseCommitReferencesTask>();
                 containerBuilder.RegisterType<FilterVersionsTask>();
@@ -139,6 +140,7 @@ namespace Grynwald.ChangeLog
                     var pipeline = new ChangeLogPipelineBuilder(container)
                         .AddTask<LoadCurrentVersionTask>()
                         .AddTask<LoadVersionsFromTagsTask>()
+                        .AddTask<LoadCommitsTask>()
                         .AddTask<ParseCommitsTask>()
                         .AddTask<ParseCommitReferencesTask>()
                         .AddTask<ParseWebLinksTask>()

--- a/src/ChangeLog/Tasks/LoadCommitsTask.cs
+++ b/src/ChangeLog/Tasks/LoadCommitsTask.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Grynwald.ChangeLog.Git;
+using Grynwald.ChangeLog.Model;
+using Grynwald.ChangeLog.Pipeline;
+using Microsoft.Extensions.Logging;
+
+namespace Grynwald.ChangeLog.Tasks
+{
+    [AfterTask(typeof(LoadVersionsFromTagsTask))]
+    [AfterTask(typeof(LoadCurrentVersionTask))]
+    [BeforeTask(typeof(RenderTemplateTask))]
+    internal sealed class LoadCommitsTask : SynchronousChangeLogTask
+    {
+        private readonly ILogger<LoadCommitsTask> m_Logger;
+        private readonly IGitRepository m_Repository;
+
+
+        public LoadCommitsTask(ILogger<LoadCommitsTask> logger, IGitRepository repository)
+        {
+            m_Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            m_Repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        }
+
+
+        protected override ChangeLogTaskResult Run(ApplicationChangeLog changeLog)
+        {
+            if (!changeLog.Versions.Any())
+            {
+                m_Logger.LogWarning("Changelog is empty, skipping loading of commit messages");
+                return ChangeLogTaskResult.Skipped;
+            }
+
+            m_Logger.LogInformation("Loading commits");
+
+            var sortedVersions = changeLog.Versions
+                .OrderByDescending(x => x.Version)
+                .ToArray();
+
+            for (var i = 0; i < sortedVersions.Length; i++)
+            {
+                var current = sortedVersions[i];
+                var previous = i + 1 < sortedVersions.Length ? sortedVersions[i + 1] : null;
+
+                IReadOnlyList<GitCommit> commits;
+                if (previous is null)
+                {
+                    m_Logger.LogDebug($"Adding all commits up to '{current.Commit.Id}' to version '{current.Version.Version}'");
+                    commits = m_Repository.GetCommits(null, current.Commit);
+                }
+                else
+                {
+                    m_Logger.LogDebug($"Adding commits between '{previous.Commit.Id}' and '{current.Commit.Id}' to version '{current.Version.Version}'");
+                    commits = m_Repository.GetCommits(previous.Commit, current.Commit);
+                }
+
+                foreach (var commit in commits)
+                {
+                    changeLog[current].Add(commit);
+                }
+            }
+
+            return ChangeLogTaskResult.Success;
+        }
+    }
+}

--- a/src/ChangeLog/Tasks/ParseCommitsTask.cs
+++ b/src/ChangeLog/Tasks/ParseCommitsTask.cs
@@ -10,21 +10,18 @@ using Microsoft.Extensions.Logging;
 
 namespace Grynwald.ChangeLog.Tasks
 {
-    [AfterTask(typeof(LoadVersionsFromTagsTask))]
-    [AfterTask(typeof(LoadCurrentVersionTask))]
+    [AfterTask(typeof(LoadCommitsTask))]
     [BeforeTask(typeof(RenderTemplateTask))]
     internal sealed class ParseCommitsTask : SynchronousChangeLogTask
     {
         private readonly ILogger<ParseCommitsTask> m_Logger;
         private readonly ChangeLogConfiguration m_Configuration;
-        private readonly IGitRepository m_Repository;
 
 
-        public ParseCommitsTask(ILogger<ParseCommitsTask> logger, ChangeLogConfiguration configuration, IGitRepository repository)
+        public ParseCommitsTask(ILogger<ParseCommitsTask> logger, ChangeLogConfiguration configuration)
         {
             m_Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             m_Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            m_Repository = repository ?? throw new ArgumentNullException(nameof(repository));
         }
 
 
@@ -38,23 +35,14 @@ namespace Grynwald.ChangeLog.Tasks
 
             m_Logger.LogInformation("Parsing commit messages");
 
-            var sortedVersions = changeLog.Versions
-                .OrderByDescending(x => x.Version)
-                .ToArray();
-
-            for (var i = 0; i < sortedVersions.Length; i++)
+            foreach (var versionChangeLog in changeLog.ChangeLogs)
             {
-                var current = sortedVersions[i];
-                var previous = i + 1 < sortedVersions.Length ? sortedVersions[i + 1] : null;
-
-                var commits = m_Repository.GetCommits(previous?.Commit, current.Commit);
-
-                foreach (var commit in commits)
+                foreach (var commit in versionChangeLog.AllCommits)
                 {
                     if (TryGetChangeLogEntry(commit, out var entry))
                     {
-                        m_Logger.LogDebug($"Adding changelog entry for commit '{commit.Id}' to version '{current.Version}'");
-                        changeLog[current].Add(entry);
+                        m_Logger.LogDebug($"Adding changelog entry for commit '{commit.Id}' to version '{versionChangeLog.Version.Version}'");
+                        versionChangeLog.Add(entry);
                     }
                 }
             }


### PR DESCRIPTION
Add the option to override a commit's message through a specially formatted comment on GitHub.
When present, the comment text will replace the commit's message for further processing.

This allows to either add or remove a entry from the generated change log through either adding a conventional commit message to a commit or setting the message to an unparsable value.

### TODOs

- [x] Split loading and parsing into separate tasks
- [ ] Load "override comments" from GitHub
- [ ] Add settings to enable/disable behaviour
- [ ] Update documentation
- [ ] Limit comments that can change the change log to certain users?