### PR TITLE
feat: Add option to override a commit's message through files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,9 @@ For example setting `key:subkey` to `value` would need to be specified in the co
   - [Normalize References](./configuration/settings/html-template.md#normalize-references)
 - [Commit Message Overrides](./configuration/settings/message-overrides.md)
   - [Enable Message Overrides](./configuration/settings/message-overrides.md#enable-message-overrides)
+  - [Message Override Provider](./configuration/settings/message-overrides.md#message-override-provider)
   - [Git Notes Namespace](./configuration/settings/message-overrides.md#git-notes-namespace)
+  - [Source Directory Path](./configuration/settings/message-overrides.md#source-directory-path)
 
 
 ## See Also

--- a/docs/configuration/settings/message-overrides.md
+++ b/docs/configuration/settings/message-overrides.md
@@ -35,11 +35,50 @@ Commit Message Override Settings control the behavior of the ["Commit Message Ov
     </tr>
     <tr>
         <td><b>Version Support</b></td>
-        <td>0.5+</td>
+        <td>1.0+</td>
     </tr>
 </table>
 
 Enabled/disables the ["Commit Message Overrides" feature](../../message-overrides.md).
+
+## Message Override Provider
+
+
+<table>
+    <tr>
+        <td><b>Setting</b></td>
+        <td><code>changelog:messageOverrides:provider</code></td>
+    </tr>
+    <tr>
+        <td><b>Environment Variable</b></td>
+        <td><code>CHANGELOG__MESSAGEOVERRIDES__PROVIDER</code></td>
+    </tr>
+    <tr>
+        <td><b>Commandline Parameter</b></td>
+        <td>
+            -
+        </td>
+    </tr>
+    <tr>
+        <td><b>Default value</b></td>
+        <td>
+            <code>GitNotes</code>
+        </td>
+    </tr>
+    <tr>
+        <td><b>Allowed values</b></td>
+        <td>
+            <ul>
+                <li><code>GitNotes</code></li>
+                <li><code>FileSystem</code></li>
+            </ul>
+        </td>
+    </tr>    
+    <tr>
+        <td><b>Version Support</b></td>
+        <td>1.1+</td>
+    </tr>
+</table>
 
 
 ## Git Notes Namespace
@@ -69,14 +108,48 @@ Enabled/disables the ["Commit Message Overrides" feature](../../message-override
     </tr>
     <tr>
         <td><b>Version Support</b></td>
-        <td>0.5+</td>
+        <td>1.0+</td>
     </tr>
 </table>
 
 
-Configures the "git notes namespace" to search for override messages.
+Configures the "git notes namespace" to search for override messages when the [provider](#message-override-provider) is set to `GitNotes`.
+
 By default, override messages are read from the `changelog/message-overrides` namespace.
 
+## Source Directory Path
+
+
+<table>
+    <tr>
+        <td><b>Setting</b></td>
+        <td><code>changelog:messageOverrides:sourceDirectoryPath</code></td>
+    </tr>
+    <tr>
+        <td><b>Environment Variable</b></td>
+        <td><code>CHANGELOG__MESSAGEOVERRIDES__SOURCEDIRECTORYPATH</code></td>
+    </tr>
+    <tr>
+        <td><b>Commandline Parameter</b></td>
+        <td>
+            -
+        </td>
+    </tr>
+    <tr>
+        <td><b>Default value</b></td>
+        <td>
+            <code>.config/changelog/message-overrides</code>
+        </td>
+    </tr>
+    <tr>
+        <td><b>Version Support</b></td>
+        <td>1.1+</td>
+    </tr>
+</table>
+
+Sets the path of the directory to load message overrides from, if the [provider](#message-override-provider) is set to `FileSystem`.
+
+If the value is a relative path, it is interpreted as being relative to the repository root directory.
 
 ## See Also
 

--- a/docs/configuration/settings/message-overrides.md.scriban
+++ b/docs/configuration/settings/message-overrides.md.scriban
@@ -39,11 +39,62 @@ Commit Message Override Settings control the behavior of the ["Commit Message Ov
     </tr>
     <tr>
         <td><b>Version Support</b></td>
-        <td>0.5+</td>
+        <td>1.0+</td>
     </tr>
 </table>
 
 Enabled/disables the ["Commit Message Overrides" feature](../../message-overrides.md).
+
+## Message Override Provider
+
+{{~
+    settingskey = "changelog:messageOverrides:provider"
+~}}
+
+<table>
+    <tr>
+        <td><b>Setting</b></td>
+        <td><code>{{settingskey}}</code></td>
+    </tr>
+    <tr>
+        <td><b>Environment Variable</b></td>
+        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
+    </tr>
+    <tr>
+        <td><b>Commandline Parameter</b></td>
+        <td>
+        {{~ if configuration.get_commandline_parameter settingskey ~}}
+            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
+        {{~ else ~}}
+            -
+        {{~ end ~}}
+        </td>
+    </tr>
+    <tr>
+        <td><b>Default value</b></td>
+        <td>
+            {{~ if configuration.get_scalar settingskey ~}}
+            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
+            {{~ else ~}}
+            -
+            {{~ end ~}}
+        </td>
+    </tr>
+    <tr>
+        <td><b>Allowed values</b></td>
+        <td>
+            <ul>
+                {{~ for item in (configuration.get_allowed_values settingskey) ~}}
+                <li><code>{{item}}</code></li>
+                {{~ end ~}}
+            </ul>
+        </td>
+    </tr>    
+    <tr>
+        <td><b>Version Support</b></td>
+        <td>1.1+</td>
+    </tr>
+</table>
 
 
 ## Git Notes Namespace
@@ -84,14 +135,59 @@ Enabled/disables the ["Commit Message Overrides" feature](../../message-override
     </tr>
     <tr>
         <td><b>Version Support</b></td>
-        <td>0.5+</td>
+        <td>1.0+</td>
     </tr>
 </table>
 
 
-Configures the "git notes namespace" to search for override messages.
+Configures the "git notes namespace" to search for override messages when the [provider](#message-override-provider) is set to `GitNotes`.
+
 By default, override messages are read from the `{{configuration.get_scalar settingskey | html.escape}}` namespace.
 
+## Source Directory Path
+
+{{~
+    settingskey = "changelog:messageOverrides:sourceDirectoryPath"
+~}}
+
+<table>
+    <tr>
+        <td><b>Setting</b></td>
+        <td><code>{{settingskey}}</code></td>
+    </tr>
+    <tr>
+        <td><b>Environment Variable</b></td>
+        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
+    </tr>
+    <tr>
+        <td><b>Commandline Parameter</b></td>
+        <td>
+        {{~ if configuration.get_commandline_parameter settingskey ~}}
+            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
+        {{~ else ~}}
+            -
+        {{~ end ~}}
+        </td>
+    </tr>
+    <tr>
+        <td><b>Default value</b></td>
+        <td>
+            {{~ if configuration.get_scalar settingskey ~}}
+            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
+            {{~ else ~}}
+            -
+            {{~ end ~}}
+        </td>
+    </tr>
+    <tr>
+        <td><b>Version Support</b></td>
+        <td>1.1+</td>
+    </tr>
+</table>
+
+Sets the path of the directory to load message overrides from, if the [provider](#message-override-provider) is set to `FileSystem`.
+
+If the value is a relative path, it is interpreted as being relative to the repository root directory.
 
 ## See Also
 

--- a/docs/message-overrides.md
+++ b/docs/message-overrides.md
@@ -7,46 +7,57 @@
 -->
 # Commit Message Overrides
 
-**Supported versions:** 0.5+
+**Supported versions:** 1.0+
 
 By default, changelog parses commit messages to generate the change log.
 Since the commit message in git cannot (easily) be changed after committing, the change log entry cannot be changed afterwards either.
-To allow editing the message used for generating the change log, version 0.5 introduced the concept of "Commit Message Overrides".
 
-It uses ["git notes"](https://git-scm.com/docs/git-notes) to set a message that takes precedence over a commit's message.
+To allow editing the message used for generating the change log, changelog supports "Commit Message Overrides" which allow specifying a message that will be user by changelog instead of the commit message.
 
-By default, the "override message" is read from the `changelog/message-overrides` namespace.
-This can be customized through the [Git Notes Namespace setting](./configuration/settings/message-overrides.md#git-notes-namespace).
+There are two ways to provide an alternate message for a commit:
 
-Note that when a git note is present, it **always** takes precedence over the commit message, regardless of whether the commit message and/or the override message can be parsed as conventional commit.
+- [Git Notes](#overriding-commit-messages-through-git-notes), added in version 1.0 (**default**)
+- [Message Override Files](#overriding-commit-messages-through-override-files), added in version 1.1
+
+By default, the Git Notes are used.
+This can be customized through the [Message Override Provider setting](./configuration/settings/message-overrides.md#message-override-provider).
+
+Both approaches have different advantages and downsides:
+
+- [Git notes](https://git-scm.com/docs/git-notes) are a little difficult to handle as git will not fetch them by default but can be accessed independently of the currently checked out commit.
+- Placing override files in the repository is more straight-forward but it may clutter the repository and you need to make sure to have the right branch checked out when generating the change log.
+
+Note that when a override message is found, it **always** takes precedence over the commit message, regardless of whether the commit message and/or the override message can be parsed as conventional commit.
 
 ## Use Cases:
 
 - **Modifying a change log entry:**
 
-  Assuming a commit's message is a valid conventional commit, the resulting change log entry can be modified, by adding a git note that is a valid conventional commit message as well.
+  Assuming a commit's message is a valid conventional commit, the resulting change log entry can be modified, by adding a override message that is a valid conventional commit message as well.
 
 - **Adding a change log entry:**
 
   Commit messages which do not follow the conventional commits format will be ignored when generating the change log.
-  To include the commit in the change log, add a git note which follows the conventional commits format.
+  To include the commit in the change log, add a override message which follows the conventional commits format.
 
 - **Removing a change log entry**
 
-  To remove a commit from the change log, add a git note that does *not* follow the conventional commits format.
+  To remove a commit from the change log, add a override message that does *not* follow the conventional commits format.
   When generating the changelog, the commit will be ignored.
 
 ## Disabling Message Overrides
 
 The commit message overrides are enabled by default. 
-Overrides can be disabled by setting the ["Enable Message Overrides"](./configuration/settings/message-overrides.md#enable-message-overrides) setting to `false`.
+Overrides can be disabled by setting the [Enable Message Overrides](./configuration/settings/message-overrides.md#enable-message-overrides) setting to `false`.
 
-## Working with Git Notes
+## Overriding Commit Messages through Git Notes
+
+When commit message overrides are configured to use git notes (see [Message Override Provider setting](./configuration/settings/message-overrides.md#message-override-provider)), override messages are read from the git notes namespace `changelog/message-overrides` .
+This can be customized through the [Git Notes Namespace setting](./configuration/settings/message-overrides.md#git-notes-namespace).
+
+### Working with Git Notes
 
 For more information on git notes, please refer to the [Git Documentation](https://git-scm.com/docs/git-notes).
-
-By default, changelog looks for override messages in the namespace `changelog/message-overrides`.
-This can be customized through the [Git Notes Namespace setting](./configuration/settings/message-overrides.md#git-notes-namespace).
 
 To add an override message, run
 
@@ -81,7 +92,7 @@ git log --show-notes=*
 ```
 
 
-## Pushing
+### Pushing
 
 **⚠️ Note that git does not include notes by default in push or pull operations**
 
@@ -105,6 +116,40 @@ git fetch origin "refs/notes/changelog/message-overrides:refs/notes/changelog/me
 git fetch origin "refs/notes/*:refs/notes/*"
 ```
 
+## Overriding Commit Messages through Override Files
+
+As an alternative to using git-notes, version 1.1 added the option to load override messages from the file system.
+
+To use the file system, set the [Message Override Provider setting](./configuration/settings/message-overrides.md#message-override-provider) to `FileSystem`.
+
+When enabled, changelog will search the directory `.config/changelog/message-overrides` (in the repository) for override files.
+In this directory, place one or more text files which are named after the id of the git commit you wish to override the message for (without a file extension).
+
+You can use the abbreviated commit id instead of the full 40-character id, but changelog will throw an error if multiple files in the directory resolve to the same commit
+(e.g. when files for both the abbreviated and the full commit id are present).
+
+For example, your repository with override files could look something like this:
+
+```txt
+<root>
+ └─.config
+    └─changelog
+       └─message-overrides
+          ├─ff186833f7a546173e77b43951bd94d57f4ccd82
+          ├─3963110882b7e85dd4de9cfb4b140a9ad661b754
+          └─a11f9b7
+```
+
+You can customize the directory to use for message overrides through the [Source Directory Path setting](./configuration/settings/message-overrides.md#source-directory-path).
+
+💡Tip: To initialize a override file with the commit's original message, you can run
+
+```ps1
+git show -s --format=%B <COMMIT> > .\.config\changelog\message-overrides\<COMMIT>
+```
+
+where `<COMMIT>` is the SHA1 of the commit to set the message for.
+<COMMIT>
 ## See Also
 
 - [Commit Message Override Settings](./configuration/settings/message-overrides.md)

--- a/docs/message-overrides.md.scriban
+++ b/docs/message-overrides.md.scriban
@@ -1,53 +1,65 @@
 {{~
-    defaultNamespace = configuration.get_scalar "changelog:messageOverrides:gitNotesNamespace" | html.escape
+    defaultGitNotesNamespace = configuration.get_scalar "changelog:messageOverrides:gitNotesNamespace" | html.escape
+    defaultSourceDirectory = configuration.get_scalar "changelog:messageOverrides:sourceDirectoryPath" | html.escape
 ~}}
 # Commit Message Overrides
 
-**Supported versions:** 0.5+
+**Supported versions:** 1.0+
 
 By default, changelog parses commit messages to generate the change log.
 Since the commit message in git cannot (easily) be changed after committing, the change log entry cannot be changed afterwards either.
-To allow editing the message used for generating the change log, version 0.5 introduced the concept of "Commit Message Overrides".
 
-It uses ["git notes"](https://git-scm.com/docs/git-notes) to set a message that takes precedence over a commit's message.
+To allow editing the message used for generating the change log, changelog supports "Commit Message Overrides" which allow specifying a message that will be user by changelog instead of the commit message.
 
-By default, the "override message" is read from the `{{defaultNamespace}}` namespace.
-This can be customized through the [Git Notes Namespace setting](./configuration/settings/message-overrides.md#git-notes-namespace).
+There are two ways to provide an alternate message for a commit:
 
-Note that when a git note is present, it **always** takes precedence over the commit message, regardless of whether the commit message and/or the override message can be parsed as conventional commit.
+- [Git Notes](#overriding-commit-messages-through-git-notes), added in version 1.0 (**default**)
+- [Message Override Files](#overriding-commit-messages-through-override-files), added in version 1.1
+
+By default, the Git Notes are used.
+This can be customized through the [Message Override Provider setting](./configuration/settings/message-overrides.md#message-override-provider).
+
+Both approaches have different advantages and downsides:
+
+- [Git notes](https://git-scm.com/docs/git-notes) are a little difficult to handle as git will not fetch them by default but can be accessed independently of the currently checked out commit.
+- Placing override files in the repository is more straight-forward but it may clutter the repository and you need to make sure to have the right branch checked out when generating the change log.
+
+Note that when a override message is found, it **always** takes precedence over the commit message, regardless of whether the commit message and/or the override message can be parsed as conventional commit.
 
 ## Use Cases:
 
 - **Modifying a change log entry:**
 
-  Assuming a commit's message is a valid conventional commit, the resulting change log entry can be modified, by adding a git note that is a valid conventional commit message as well.
+  Assuming a commit's message is a valid conventional commit, the resulting change log entry can be modified, by adding a override message that is a valid conventional commit message as well.
 
 - **Adding a change log entry:**
 
   Commit messages which do not follow the conventional commits format will be ignored when generating the change log.
-  To include the commit in the change log, add a git note which follows the conventional commits format.
+  To include the commit in the change log, add a override message which follows the conventional commits format.
 
 - **Removing a change log entry**
 
-  To remove a commit from the change log, add a git note that does *not* follow the conventional commits format.
+  To remove a commit from the change log, add a override message that does *not* follow the conventional commits format.
   When generating the changelog, the commit will be ignored.
 
 ## Disabling Message Overrides
 
 The commit message overrides are enabled by default. 
-Overrides can be disabled by setting the ["Enable Message Overrides"](./configuration/settings/message-overrides.md#enable-message-overrides) setting to `false`.
+Overrides can be disabled by setting the [Enable Message Overrides](./configuration/settings/message-overrides.md#enable-message-overrides) setting to `false`.
 
-## Working with Git Notes
+## Overriding Commit Messages through Git Notes
+
+When commit message overrides are configured to use git notes (see [Message Override Provider setting](./configuration/settings/message-overrides.md#message-override-provider)), override messages are read from the git notes namespace `{{defaultGitNotesNamespace}}` .
+This can be customized through the [Git Notes Namespace setting](./configuration/settings/message-overrides.md#git-notes-namespace).
+
+### Working with Git Notes
 
 For more information on git notes, please refer to the [Git Documentation](https://git-scm.com/docs/git-notes).
-
-By default, changelog looks for override messages in the namespace `{{defaultNamespace}}`.
-This can be customized through the [Git Notes Namespace setting](./configuration/settings/message-overrides.md#git-notes-namespace).
 
 To add an override message, run
 
 ```ps1
-git notes --ref "{{defaultNamespace}}" add "<COMMIT>"
+git notes --ref "{{defaultGitNotesNamespace}}" add "<COMMIT>"
 ```
 
 where `<COMMIT>` is the SHA1 of the commit to add a note to.
@@ -56,13 +68,13 @@ where `<COMMIT>` is the SHA1 of the commit to add a note to.
 Similarly, notes can be edited by running
 
 ```ps1
-git notes --ref "{{defaultNamespace}}" edit "<COMMIT>"
+git notes --ref "{{defaultGitNotesNamespace}}" edit "<COMMIT>"
 ```
 
 or removed using 
 
 ```ps1
-git notes --ref "{{defaultNamespace}}" remove "<COMMIT>"
+git notes --ref "{{defaultGitNotesNamespace}}" remove "<COMMIT>"
 ```
 
 
@@ -70,14 +82,14 @@ To show message overrides in the output of `git log`, run
 
 ```ps1
 # Include "changelog message overrides" in the output of git log
-git log --show-notes={{defaultNamespace}}
+git log --show-notes={{defaultGitNotesNamespace}}
 
 # Show *all* notes in the output of git log
 git log --show-notes=*
 ```
 
 
-## Pushing
+### Pushing
 
 **⚠️ Note that git does not include notes by default in push or pull operations**
 
@@ -85,7 +97,7 @@ To push git notes, run
 
 ```ps1
 # Fetch changelog message overrides
-git push origin "refs/notes/{{defaultNamespace}}"
+git push origin "refs/notes/{{defaultGitNotesNamespace}}"
 
 # Push all notes
 git push origin "refs/notes/*"
@@ -95,12 +107,46 @@ Before generating the change log, ensure that git notes have been fetched into t
 
 ```ps1
 # Fetch notes for the message override namespace
-git fetch origin "refs/notes/{{defaultNamespace}}:refs/notes/{{defaultNamespace}}"
+git fetch origin "refs/notes/{{defaultGitNotesNamespace}}:refs/notes/{{defaultGitNotesNamespace}}"
 
 # Fetch all notes
 git fetch origin "refs/notes/*:refs/notes/*"
 ```
 
+## Overriding Commit Messages through Override Files
+
+As an alternative to using git-notes, version 1.1 added the option to load override messages from the file system.
+
+To use the file system, set the [Message Override Provider setting](./configuration/settings/message-overrides.md#message-override-provider) to `FileSystem`.
+
+When enabled, changelog will search the directory `{{defaultSourceDirectory}}` (in the repository) for override files.
+In this directory, place one or more text files which are named after the id of the git commit you wish to override the message for (without a file extension).
+
+You can use the abbreviated commit id instead of the full 40-character id, but changelog will throw an error if multiple files in the directory resolve to the same commit
+(e.g. when files for both the abbreviated and the full commit id are present).
+
+For example, your repository with override files could look something like this:
+
+```txt
+<root>
+ └─.config
+    └─changelog
+       └─message-overrides
+          ├─ff186833f7a546173e77b43951bd94d57f4ccd82
+          ├─3963110882b7e85dd4de9cfb4b140a9ad661b754
+          └─a11f9b7
+```
+
+You can customize the directory to use for message overrides through the [Source Directory Path setting](./configuration/settings/message-overrides.md#source-directory-path).
+
+💡Tip: To initialize a override file with the commit's original message, you can run
+
+```ps1
+git show -s --format=%B <COMMIT> > .\.config\changelog\message-overrides\<COMMIT>
+```
+
+where `<COMMIT>` is the SHA1 of the commit to set the message for.
+<COMMIT>
 ## See Also
 
 - [Commit Message Override Settings](./configuration/settings/message-overrides.md)

--- a/schemas/configuration/schema.json
+++ b/schemas/configuration/schema.json
@@ -666,10 +666,24 @@
               "default": true,
               "title": "Enable Commit Message Overrides"
             },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "GitNotes",
+                "FileSystem"
+              ],
+              "default": "GitNotes",
+              "title": "Commit Message Override Provider"
+            },
             "gitNotesNamespace": {
               "type": "string",
               "default": "changelog/message-overrides",
               "title": "Commit Message Overide Git Notes Namespace"
+            },
+            "sourceDirectoryPath": {
+              "type": "string",
+              "default": ".config/changelog/message-overrides",
+              "title": "Commit Message Override Source Directory"
             }
           }
         }

--- a/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
+++ b/src/ChangeLog.Test/Configuration/ChangeLogConfigurationLoaderTest.cs
@@ -291,7 +291,9 @@ namespace Grynwald.ChangeLog.Test.Configuration
             // Message override settings
             //
             yield return TestCase(config => Assert.True(config.MessageOverrides.Enabled));
+            yield return TestCase(config => Assert.Equal(ChangeLogConfiguration.MessageOverrideProvider.GitNotes, config.MessageOverrides.Provider));
             yield return TestCase(config => Assert.Equal("changelog/message-overrides", config.MessageOverrides.GitNotesNamespace));
+            yield return TestCase(config => Assert.Equal(".config/changelog/message-overrides", config.MessageOverrides.SourceDirectoryPath));
         }
 
         [Theory]
@@ -701,7 +703,13 @@ namespace Grynwald.ChangeLog.Test.Configuration
             yield return TestCase("messageOverrides:enabled", config => config.MessageOverrides.Enabled, true);
             yield return TestCase("messageOverrides:enabled", config => config.MessageOverrides.Enabled, false);
 
+            foreach (var value in GetEnumValues<ChangeLogConfiguration.MessageOverrideProvider>())
+            {
+                yield return TestCase("messageOverrides:provider", config => config.MessageOverrides.Provider, value);
+            }
+
             yield return TestCase("messageOverrides:gitNotesNamespace", config => config.MessageOverrides.GitNotesNamespace, "some-namespace");
+            yield return TestCase("messageOverrides:sourceDirectoryPath", config => config.MessageOverrides.SourceDirectoryPath, "custom-source-directory");
         }
 
         public static IEnumerable<object?[]> ConfigurationFileSetValueTestCases() =>

--- a/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
+++ b/src/ChangeLog.Test/Configuration/ConfigurationValidatorTest.cs
@@ -841,6 +841,25 @@ namespace Grynwald.ChangeLog.Test.Configuration
         }
 
 
+        [Fact]
+        public void MessageOverrides_Provider_must_be_defined_value()
+        {
+            // ARRANGE
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            config.MessageOverrides.Provider = (ChangeLogConfiguration.MessageOverrideProvider)(-1);
+
+            var sut = new ConfigurationValidator();
+
+            // ACT 
+            var result = sut.Validate(config);
+
+            // ASSERT
+            Assert.False(result.IsValid);
+            Assert.Collection(result.Errors,
+                error => Assert.Contains("'Commit Message Override Provider'", error.ErrorMessage)
+            );
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -866,16 +885,82 @@ namespace Grynwald.ChangeLog.Test.Configuration
         }
 
         [Theory]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, null)]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, "")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, "\t")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, "  ")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, null)]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, "")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, "\t")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, "  ")]
+        [InlineData(true, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, null)]
+        [InlineData(true, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, "")]
+        [InlineData(true, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, "\t")]
+        [InlineData(true, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, "  ")]
+        public void MessageOverrides_GitNotesNamespace_may_be_null_or_whitespace_when_message_overrides_are_disabled_or_another_provider_is_used(bool enabled, ChangeLogConfiguration.MessageOverrideProvider provider, string gitNotesNamespace)
+        {
+            // ARRANGE
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            config.MessageOverrides.Enabled = enabled;
+            config.MessageOverrides.Provider = provider;
+            config.MessageOverrides.GitNotesNamespace = gitNotesNamespace;
+
+            var sut = new ConfigurationValidator();
+
+            // ACT 
+            var result = sut.Validate(config);
+
+            // ASSERT
+            Assert.True(result.IsValid);
+            Assert.Empty(result.Errors);
+        }
+
+
+        [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("\t")]
         [InlineData("  ")]
-        public void MessageOverrides_GitNotesNamespace_may_be_null_or_whitespace_when_message_overrides_are_disabled(string gitNotesNamespace)
+        public void MessageOverrides_SourceDirectoryPath_must_not_be_null_or_whitespace_when_message_overrides_are_enabled(string sourceDirectoryPath)
         {
             // ARRANGE
             var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
-            config.MessageOverrides.Enabled = false;
-            config.MessageOverrides.GitNotesNamespace = gitNotesNamespace;
+            config.MessageOverrides.Enabled = true;
+            config.MessageOverrides.Provider = ChangeLogConfiguration.MessageOverrideProvider.FileSystem;
+            config.MessageOverrides.SourceDirectoryPath = sourceDirectoryPath;
+
+            var sut = new ConfigurationValidator();
+
+            // ACT 
+            var result = sut.Validate(config);
+
+            // ASSERT
+            Assert.False(result.IsValid);
+            Assert.Collection(result.Errors,
+                error => Assert.Contains("'Commit Message Override Source Directory'", error.ErrorMessage)
+            );
+        }
+
+        [Theory]
+        [InlineData(true, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, null)]
+        [InlineData(true, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, "")]
+        [InlineData(true, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, "\t")]
+        [InlineData(true, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, "  ")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, null)]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, "")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, "\t")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.GitNotes, "  ")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, null)]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, "")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, "\t")]
+        [InlineData(false, ChangeLogConfiguration.MessageOverrideProvider.FileSystem, "  ")]
+        public void MessageOverrides_SourceDirectoryPath_may_be_null_or_whitespace_when_message_overrides_are_disabled_or_another_provider_is_used(bool enabled, ChangeLogConfiguration.MessageOverrideProvider provider, string sourceDirectoryPath)
+        {
+            // ARRANGE
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            config.MessageOverrides.Enabled = enabled;
+            config.MessageOverrides.Provider = provider;
+            config.MessageOverrides.SourceDirectoryPath = sourceDirectoryPath;
 
             var sut = new ConfigurationValidator();
 

--- a/src/ChangeLog.Test/GitRepositoryMockExtensions.cs
+++ b/src/ChangeLog.Test/GitRepositoryMockExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Grynwald.ChangeLog.Git;
 using Moq;
@@ -29,6 +30,16 @@ namespace Grynwald.ChangeLog.Test
         public static IReturnsResult<IGitRepository> SetupEmptyRemotes(this Mock<IGitRepository> mock)
         {
             return mock.Setup(x => x.Remotes).Returns(Enumerable.Empty<GitRemote>());
+        }
+
+        public static IReturnsResult<IGitRepository> SetupTryGetCommit(this Mock<IGitRepository> mock)
+        {
+            return mock.Setup(x => x.TryGetCommit(It.IsAny<string>())).Returns((GitCommit?)null);
+        }
+
+        public static IReturnsResult<IGitRepository> SetupTryGetCommit(this Mock<IGitRepository> mock, GitCommit commit)
+        {
+            return mock.Setup(x => x.TryGetCommit(It.Is<string>(str => commit.Id.Id.StartsWith(str, StringComparison.OrdinalIgnoreCase)))).Returns(commit);
         }
     }
 }

--- a/src/ChangeLog.Test/Tasks/LoadMessageOverridesFromFileSystemTaskTest.cs
+++ b/src/ChangeLog.Test/Tasks/LoadMessageOverridesFromFileSystemTaskTest.cs
@@ -1,0 +1,357 @@
+﻿using System;
+using System.Threading.Tasks;
+using Grynwald.ChangeLog.Configuration;
+using Grynwald.ChangeLog.Git;
+using Grynwald.ChangeLog.Model;
+using Grynwald.ChangeLog.Pipeline;
+using Grynwald.ChangeLog.Tasks;
+using Grynwald.Utilities.IO;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Grynwald.ChangeLog.Test.Tasks
+{
+    /// <summary>
+    /// Tests for <see cref="LoadMessageOverridesFromFileSystemTask"/>
+    /// </summary>
+    public class LoadMessageOverridesFromFileSystemTaskTest : TestBase
+    {
+        private readonly ILogger<LoadMessageOverridesFromFileSystemTask> m_Logger;
+
+
+        public LoadMessageOverridesFromFileSystemTaskTest(ITestOutputHelper testOutputHelper)
+        {
+            m_Logger = new XunitLogger<LoadMessageOverridesFromFileSystemTask>(testOutputHelper);
+        }
+
+
+        [Fact]
+        public void Logger_must_not_be_null()
+        {
+            // ARRANGE
+
+            // ACT 
+            var ex = Record.Exception(() => new LoadMessageOverridesFromFileSystemTask(logger: null!, configuration: new(), repository: Mock.Of<IGitRepository>(MockBehavior.Strict)));
+
+            // ASSERT
+            var argumentNullException = Assert.IsType<ArgumentNullException>(ex);
+            Assert.Equal("logger", argumentNullException.ParamName);
+        }
+
+        [Fact]
+        public void Configuration_must_not_be_null()
+        {
+            // ARRANGE
+
+            // ACT 
+            var ex = Record.Exception(() => new LoadMessageOverridesFromFileSystemTask(logger: m_Logger, configuration: null!, repository: Mock.Of<IGitRepository>(MockBehavior.Strict)));
+
+            // ASSERT
+            var argumentNullException = Assert.IsType<ArgumentNullException>(ex);
+            Assert.Equal("configuration", argumentNullException.ParamName);
+        }
+
+        [Fact]
+        public void Repository_must_not_be_null()
+        {
+            // ARRANGE
+
+            // ACT 
+            var ex = Record.Exception(() => new LoadMessageOverridesFromFileSystemTask(logger: m_Logger, configuration: new(), repository: null!));
+
+            // ASSERT
+            var argumentNullException = Assert.IsType<ArgumentNullException>(ex);
+            Assert.Equal("repository", argumentNullException.ParamName);
+        }
+
+        [Fact]
+        public async Task Task_does_nothing_for_empty_changelog()
+        {
+            // ARRANGE
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            var repo = new Mock<IGitRepository>(MockBehavior.Strict);
+
+            var sut = new LoadMessageOverridesFromFileSystemTask(m_Logger, config, repo.Object);
+
+            // ACT
+            var changelog = new ApplicationChangeLog();
+            var result = await sut.RunAsync(changelog);
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Skipped, result);
+        }
+
+        [Theory]
+        [InlineData("X:\\Does-not-exist")]
+        [InlineData("/Does-not-exist")]
+        [InlineData("does-not-exist")]
+        public async Task Task_succeeds_if_override_directory_does_not_exist(string sourceDirectoryPath)
+        {
+            // ARRANGE
+            using var repositoryDirectory = new TemporaryDirectory();
+
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            {
+                config.RepositoryPath = repositoryDirectory;
+                config.MessageOverrides.SourceDirectoryPath = sourceDirectoryPath;
+            }
+
+            var commit1 = GetGitCommit(id: TestGitIds.Id1, commitMessage: "Original Message 1");
+            var commit2 = GetGitCommit(id: TestGitIds.Id2, commitMessage: "Original Message 2");
+
+            var repo = new Mock<IGitRepository>(MockBehavior.Strict);
+
+            var versionChangeLog = GetSingleVersionChangeLog("1.2.3", TestGitIds.Id1);
+            {
+                versionChangeLog.Add(commit1);
+                versionChangeLog.Add(commit2);
+            }
+
+            var sut = new LoadMessageOverridesFromFileSystemTask(m_Logger, config, repo.Object);
+
+            // ACT
+            var result = await sut.RunAsync(new ApplicationChangeLog() { versionChangeLog });
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+            Assert.Collection(
+                versionChangeLog.AllCommits,
+                c => Assert.Equal(commit1, c),
+                c => Assert.Equal(commit2, c)
+            );
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(".config/changelog/message-overrides")]
+        [InlineData("custom/directory")]
+        public async Task Task_replaces_commit_messages_with_messages_from_the_configured_directory(string? sourceDirectoryPath)
+        {
+            // ARRANGE
+            using var repositoryDirectory = new TemporaryDirectory();
+
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            {
+                config.RepositoryPath = repositoryDirectory;
+
+                if (sourceDirectoryPath is not null)
+                    config.MessageOverrides.SourceDirectoryPath = sourceDirectoryPath;
+            }
+
+
+            var commit1 = GetGitCommit(id: TestGitIds.Id1, commitMessage: "Original Message 1");
+            var commit2 = GetGitCommit(id: TestGitIds.Id2, commitMessage: "Original Message 2");
+
+            var repo = new Mock<IGitRepository>(MockBehavior.Strict);
+            {
+                repo.SetupTryGetCommit();
+                repo.SetupTryGetCommit(commit1);
+                repo.SetupTryGetCommit(commit2);
+            }
+
+            var versionChangeLog = GetSingleVersionChangeLog("1.2.3", TestGitIds.Id1);
+            {
+                versionChangeLog.Add(commit1);
+                versionChangeLog.Add(commit2);
+            }
+
+            repositoryDirectory.AddFile(
+                $"{sourceDirectoryPath ?? ".config/changelog/message-overrides"}/{commit2.Id.ToString(abbreviate: false)}",
+                "Overridden Message 2");
+
+            var sut = new LoadMessageOverridesFromFileSystemTask(m_Logger, config, repo.Object);
+
+            // ACT
+            var result = await sut.RunAsync(new ApplicationChangeLog() { versionChangeLog });
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+            Assert.Collection(
+                versionChangeLog.AllCommits,
+                c => Assert.Equal(commit1, c),
+                c => Assert.Equal(commit2.WithCommitMessage("Overridden Message 2"), c)
+            );
+        }
+
+        [Fact]
+        public async Task Task_replaces_commit_messages_with_messages_from_the_directory_configured_using_an_absolute_path()
+        {
+            // ARRANGE
+            using var repositoryDirectory = new TemporaryDirectory();
+            using var overridesDirectory = new TemporaryDirectory();
+
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            {
+                config.RepositoryPath = repositoryDirectory;
+                config.MessageOverrides.SourceDirectoryPath = overridesDirectory;
+            }
+
+
+            var commit1 = GetGitCommit(id: TestGitIds.Id1, commitMessage: "Original Message 1");
+            var commit2 = GetGitCommit(id: TestGitIds.Id2, commitMessage: "Original Message 2");
+
+            var repo = new Mock<IGitRepository>(MockBehavior.Strict);
+            {
+                repo.SetupTryGetCommit();
+                repo.SetupTryGetCommit(commit1);
+                repo.SetupTryGetCommit(commit2);
+            }
+
+            var versionChangeLog = GetSingleVersionChangeLog("1.2.3", TestGitIds.Id1);
+            {
+                versionChangeLog.Add(commit1);
+                versionChangeLog.Add(commit2);
+            }
+
+            overridesDirectory.AddFile(commit2.Id.ToString(), "Overridden Message 2");
+
+            var sut = new LoadMessageOverridesFromFileSystemTask(m_Logger, config, repo.Object);
+
+            // ACT
+            var result = await sut.RunAsync(new ApplicationChangeLog() { versionChangeLog });
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+            Assert.Collection(
+                versionChangeLog.AllCommits,
+                c => Assert.Equal(commit1, c),
+                c => Assert.Equal(commit2.WithCommitMessage("Overridden Message 2"), c)
+            );
+        }
+
+        [Fact]
+        public async Task Task_replaces_commit_messages_if_file_name_is_abbreviated_id()
+        {
+            // ARRANGE
+            using var temporaryDirectory = new TemporaryDirectory();
+
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            {
+                config.RepositoryPath = temporaryDirectory;
+            }
+
+            var commit1 = GetGitCommit(id: TestGitIds.Id1, commitMessage: "Original Message 1");
+            var commit2 = GetGitCommit(id: TestGitIds.Id2, commitMessage: "Original Message 2");
+
+            var repo = new Mock<IGitRepository>(MockBehavior.Strict);
+            {
+                repo.SetupTryGetCommit();
+                repo.SetupTryGetCommit(commit1);
+                repo.SetupTryGetCommit(commit2);
+            }
+
+            var versionChangeLog = GetSingleVersionChangeLog("1.2.3", TestGitIds.Id1);
+            {
+                versionChangeLog.Add(commit1);
+                versionChangeLog.Add(commit2);
+            }
+
+            temporaryDirectory.AddFile(
+                $".config/changelog/message-overrides/{commit2.Id.ToString(abbreviate: true)}",
+                "Overridden Message 2");
+
+
+            var sut = new LoadMessageOverridesFromFileSystemTask(m_Logger, config, repo.Object);
+
+            // ACT
+            var result = await sut.RunAsync(new ApplicationChangeLog() { versionChangeLog });
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+            Assert.Collection(
+                versionChangeLog.AllCommits,
+                c => Assert.Equal(commit1, c),
+                c => Assert.Equal(commit2.WithCommitMessage("Overridden Message 2"), c)
+            );
+        }
+
+        [Fact]
+        public async Task Task_fails_if_multiple_files_in_the_override_directory_resolve_to_the_same_commit()
+        {
+            // ARRANGE
+            using var overrideDirectory = new TemporaryDirectory();
+
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            {
+                config.MessageOverrides.SourceDirectoryPath = overrideDirectory;
+            }
+
+            var commit1 = GetGitCommit(id: TestGitIds.Id1, commitMessage: "Original Message 1");
+            var commit2 = GetGitCommit(id: TestGitIds.Id2, commitMessage: "Original Message 2");
+
+            var repo = new Mock<IGitRepository>(MockBehavior.Strict);
+            {
+                repo.SetupTryGetCommit();
+                repo.SetupTryGetCommit(commit1);
+                repo.SetupTryGetCommit(commit2);
+            }
+
+            var versionChangeLog = GetSingleVersionChangeLog("1.2.3", TestGitIds.Id1);
+            {
+                versionChangeLog.Add(commit1);
+                versionChangeLog.Add(commit2);
+            }
+
+            overrideDirectory.AddFile(commit2.Id.ToString(abbreviate: true), "Overridden Message 2.1");
+            overrideDirectory.AddFile(commit2.Id.ToString(abbreviate: false), "Overridden Message 2.2");
+
+            var sut = new LoadMessageOverridesFromFileSystemTask(m_Logger, config, repo.Object);
+
+            // ACT
+            var result = await sut.RunAsync(new ApplicationChangeLog() { versionChangeLog });
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Error, result);
+            Assert.Collection(
+                versionChangeLog.AllCommits,
+                c => Assert.Equal(commit1, c),
+                c => Assert.Equal(commit2, c)
+            );
+        }
+
+        [Fact]
+        public async Task Task_ignores_files_in_the_override_directory_if_the_commit_cannot_be_resolved()
+        {
+            // ARRANGE
+            using var overrideDirectory = new TemporaryDirectory();
+
+            var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
+            {
+                config.MessageOverrides.SourceDirectoryPath = overrideDirectory;
+            }
+
+            var commit1 = GetGitCommit(id: TestGitIds.Id1, commitMessage: "Original Message 1");
+            var commit2 = GetGitCommit(id: TestGitIds.Id2, commitMessage: "Original Message 2");
+
+            var repo = new Mock<IGitRepository>(MockBehavior.Strict);
+            {
+                repo.SetupTryGetCommit();
+                repo.SetupTryGetCommit(commit1);
+                repo.SetupTryGetCommit(commit2);
+            }
+
+            var versionChangeLog = GetSingleVersionChangeLog("1.2.3", TestGitIds.Id1);
+            {
+                versionChangeLog.Add(commit1);
+                versionChangeLog.Add(commit2);
+            }
+
+            overrideDirectory.AddFile("not-a-commit-id", "Some content");
+
+            var sut = new LoadMessageOverridesFromFileSystemTask(m_Logger, config, repo.Object);
+
+            // ACT
+            var result = await sut.RunAsync(new ApplicationChangeLog() { versionChangeLog });
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+            Assert.Collection(
+                versionChangeLog.AllCommits,
+                c => Assert.Equal(commit1, c),
+                c => Assert.Equal(commit2, c)
+            );
+        }
+    }
+}

--- a/src/ChangeLog.Test/Tasks/LoadMessageOverridesFromGitNotesTaskTest.cs
+++ b/src/ChangeLog.Test/Tasks/LoadMessageOverridesFromGitNotesTaskTest.cs
@@ -13,16 +13,16 @@ using Xunit.Abstractions;
 namespace Grynwald.ChangeLog.Test.Tasks
 {
     /// <summary>
-    /// Tests for <see cref="LoadMessageOverridesTask"/>
+    /// Tests for <see cref="LoadMessageOverridesFromGitNotesTask"/>
     /// </summary>
-    public class LoadMessageOverridesTaskTest : TestBase
+    public class LoadMessageOverridesFromGitNotesTaskTest : TestBase
     {
-        private readonly ILogger<LoadMessageOverridesTask> m_Logger;
+        private readonly ILogger<LoadMessageOverridesFromGitNotesTask> m_Logger;
 
 
-        public LoadMessageOverridesTaskTest(ITestOutputHelper testOutputHelper)
+        public LoadMessageOverridesFromGitNotesTaskTest(ITestOutputHelper testOutputHelper)
         {
-            m_Logger = new XunitLogger<LoadMessageOverridesTask>(testOutputHelper);
+            m_Logger = new XunitLogger<LoadMessageOverridesFromGitNotesTask>(testOutputHelper);
         }
 
 
@@ -32,7 +32,7 @@ namespace Grynwald.ChangeLog.Test.Tasks
             // ARRANGE
 
             // ACT 
-            var ex = Record.Exception(() => new LoadMessageOverridesTask(logger: null!, configuration: new ChangeLogConfiguration(), repository: Mock.Of<IGitRepository>(MockBehavior.Strict)));
+            var ex = Record.Exception(() => new LoadMessageOverridesFromGitNotesTask(logger: null!, configuration: new ChangeLogConfiguration(), repository: Mock.Of<IGitRepository>(MockBehavior.Strict)));
 
             // ASSERT
             var argumentNullException = Assert.IsType<ArgumentNullException>(ex);
@@ -45,7 +45,7 @@ namespace Grynwald.ChangeLog.Test.Tasks
             // ARRANGE
 
             // ACT 
-            var ex = Record.Exception(() => new LoadMessageOverridesTask(logger: m_Logger, configuration: null!, repository: Mock.Of<IGitRepository>(MockBehavior.Strict)));
+            var ex = Record.Exception(() => new LoadMessageOverridesFromGitNotesTask(logger: m_Logger, configuration: null!, repository: Mock.Of<IGitRepository>(MockBehavior.Strict)));
 
             // ASSERT
             var argumentNullException = Assert.IsType<ArgumentNullException>(ex);
@@ -58,7 +58,7 @@ namespace Grynwald.ChangeLog.Test.Tasks
             // ARRANGE
 
             // ACT 
-            var ex = Record.Exception(() => new LoadMessageOverridesTask(logger: m_Logger, configuration: new ChangeLogConfiguration(), repository: null!));
+            var ex = Record.Exception(() => new LoadMessageOverridesFromGitNotesTask(logger: m_Logger, configuration: new ChangeLogConfiguration(), repository: null!));
 
             // ASSERT
             var argumentNullException = Assert.IsType<ArgumentNullException>(ex);
@@ -72,7 +72,7 @@ namespace Grynwald.ChangeLog.Test.Tasks
             var repo = Mock.Of<IGitRepository>(MockBehavior.Strict);
             var config = ChangeLogConfigurationLoader.GetDefaultConfiguration();
 
-            var sut = new LoadMessageOverridesTask(m_Logger, config, repo);
+            var sut = new LoadMessageOverridesFromGitNotesTask(m_Logger, config, repo);
 
             // ACT
             var changelog = new ApplicationChangeLog();
@@ -115,7 +115,7 @@ namespace Grynwald.ChangeLog.Test.Tasks
                     });
             }
 
-            var sut = new LoadMessageOverridesTask(m_Logger, config, repo.Object);
+            var sut = new LoadMessageOverridesFromGitNotesTask(m_Logger, config, repo.Object);
 
             // ACT
             var result = await sut.RunAsync(new ApplicationChangeLog() { versionChangeLog });

--- a/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
+++ b/src/ChangeLog/Configuration/ChangeLogConfiguration.cs
@@ -159,6 +159,12 @@ namespace Grynwald.ChangeLog.Configuration
             public string Scope { get; set; } = "*";
         }
 
+        public enum MessageOverrideProvider
+        {
+            GitNotes,
+            FileSystem
+        }
+
         public class MessageOverrideConfiguration
         {
             [JsonSchemaDefaultValue]
@@ -166,8 +172,16 @@ namespace Grynwald.ChangeLog.Configuration
             public bool Enabled { get; set; }
 
             [JsonSchemaDefaultValue]
+            [SettingDisplayName("Commit Message Override Provider")]
+            public MessageOverrideProvider Provider { get; set; }
+
+            [JsonSchemaDefaultValue]
             [SettingDisplayName("Commit Message Overide Git Notes Namespace")]
             public string GitNotesNamespace { get; set; } = "";
+
+            [JsonSchemaDefaultValue]
+            [SettingDisplayName("Commit Message Override Source Directory")]
+            public string SourceDirectoryPath { get; set; } = "";
         }
 
 

--- a/src/ChangeLog/Configuration/ConfigurationValidator.cs
+++ b/src/ChangeLog/Configuration/ConfigurationValidator.cs
@@ -96,9 +96,15 @@ namespace Grynwald.ChangeLog.Configuration
                 .UnlessNullOrWhiteSpace()
                 .WithMessage("Directory '{PropertyValue}' specified as '{PropertyName}' does not exists");
 
+            RuleFor(x => x.MessageOverrides.Provider).IsInEnum();
+
             RuleFor(x => x.MessageOverrides.GitNotesNamespace)
                 .NotEmpty()
-                .When(x => x.MessageOverrides.Enabled);
+                .When(x => x.MessageOverrides.Enabled && x.MessageOverrides.Provider == ChangeLogConfiguration.MessageOverrideProvider.GitNotes);
+
+            RuleFor(x => x.MessageOverrides.SourceDirectoryPath)
+                .NotEmpty()
+                .When(x => x.MessageOverrides.Enabled && x.MessageOverrides.Provider == ChangeLogConfiguration.MessageOverrideProvider.FileSystem);
         }
 
 

--- a/src/ChangeLog/Configuration/defaultSettings.json
+++ b/src/ChangeLog/Configuration/defaultSettings.json
@@ -127,7 +127,9 @@
 
     "messageOverrides": {
       "enabled": true,
-      "gitNotesNamespace": "changelog/message-overrides"
+      "provider": "GitNotes",
+      "gitNotesNamespace": "changelog/message-overrides",
+      "sourceDirectoryPath": ".config/changelog/message-overrides"
     }
   }
 }

--- a/src/ChangeLog/Program.cs
+++ b/src/ChangeLog/Program.cs
@@ -107,7 +107,7 @@ namespace Grynwald.ChangeLog
                 containerBuilder.RegisterType<LoadCurrentVersionTask>();
                 containerBuilder.RegisterType<LoadVersionsFromTagsTask>();
                 containerBuilder.RegisterType<LoadCommitsTask>();
-                containerBuilder.RegisterType<LoadMessageOverridesTask>();
+                containerBuilder.RegisterType<LoadMessageOverridesFromGitNotesTask>();
                 containerBuilder.RegisterType<ParseCommitsTask>();
                 containerBuilder.RegisterType<ParseCommitReferencesTask>();
                 containerBuilder.RegisterType<FilterVersionsTask>();
@@ -149,7 +149,7 @@ namespace Grynwald.ChangeLog
                         .AddTask<LoadCurrentVersionTask>()
                         .AddTask<LoadVersionsFromTagsTask>()
                         .AddTask<LoadCommitsTask>()
-                        .AddTaskIf<LoadMessageOverridesTask>(configuration.MessageOverrides.Enabled)
+                        .AddTaskIf<LoadMessageOverridesFromGitNotesTask>(configuration.MessageOverrides.Enabled)
                         .AddTask<ParseCommitsTask>()
                         .AddTask<ParseCommitReferencesTask>()
                         .AddTask<ParseWebLinksTask>()

--- a/src/ChangeLog/Program.cs
+++ b/src/ChangeLog/Program.cs
@@ -108,6 +108,7 @@ namespace Grynwald.ChangeLog
                 containerBuilder.RegisterType<LoadVersionsFromTagsTask>();
                 containerBuilder.RegisterType<LoadCommitsTask>();
                 containerBuilder.RegisterType<LoadMessageOverridesFromGitNotesTask>();
+                containerBuilder.RegisterType<LoadMessageOverridesFromFileSystemTask>();
                 containerBuilder.RegisterType<ParseCommitsTask>();
                 containerBuilder.RegisterType<ParseCommitReferencesTask>();
                 containerBuilder.RegisterType<FilterVersionsTask>();
@@ -149,7 +150,12 @@ namespace Grynwald.ChangeLog
                         .AddTask<LoadCurrentVersionTask>()
                         .AddTask<LoadVersionsFromTagsTask>()
                         .AddTask<LoadCommitsTask>()
-                        .AddTaskIf<LoadMessageOverridesFromGitNotesTask>(configuration.MessageOverrides.Enabled)
+                        .AddTaskIf<LoadMessageOverridesFromGitNotesTask>(
+                            configuration.MessageOverrides.Enabled && configuration.MessageOverrides.Provider == ChangeLogConfiguration.MessageOverrideProvider.GitNotes
+                        )
+                        .AddTaskIf<LoadMessageOverridesFromFileSystemTask>(
+                            configuration.MessageOverrides.Enabled && configuration.MessageOverrides.Provider == ChangeLogConfiguration.MessageOverrideProvider.FileSystem
+                        )
                         .AddTask<ParseCommitsTask>()
                         .AddTask<ParseCommitReferencesTask>()
                         .AddTask<ParseWebLinksTask>()

--- a/src/ChangeLog/Tasks/LoadMessageOverridesFromFileSystemTask.cs
+++ b/src/ChangeLog/Tasks/LoadMessageOverridesFromFileSystemTask.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Grynwald.ChangeLog.Configuration;
+using Grynwald.ChangeLog.Git;
+using Grynwald.ChangeLog.Model;
+using Grynwald.ChangeLog.Pipeline;
+using Microsoft.Extensions.Logging;
+
+namespace Grynwald.ChangeLog.Tasks
+{
+    [AfterTask(typeof(LoadCommitsTask))]
+    [BeforeTask(typeof(ParseCommitsTask))]
+    internal sealed class LoadMessageOverridesFromFileSystemTask : LoadMessageOverridesTask
+    {
+        private class DuplicateOverrideMessageException : Exception
+        { }
+
+
+        private readonly ILogger<LoadMessageOverridesFromFileSystemTask> m_Logger;
+        private readonly ChangeLogConfiguration m_Configuration;
+        private readonly IGitRepository m_Repository;
+        private Lazy<IReadOnlyDictionary<GitId, string>> m_OverrideMessages;
+
+
+        public LoadMessageOverridesFromFileSystemTask(ILogger<LoadMessageOverridesFromFileSystemTask> logger, ChangeLogConfiguration configuration, IGitRepository repository) : base(logger)
+        {
+            m_Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            m_Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            m_Repository = repository ?? throw new ArgumentNullException(nameof(repository));
+            m_OverrideMessages = new(LoadOverrideMessages);
+        }
+
+
+        protected override ChangeLogTaskResult Run(ApplicationChangeLog changelog)
+        {
+            try
+            {
+                return base.Run(changelog);
+            }
+            catch (DuplicateOverrideMessageException)
+            {
+                return ChangeLogTaskResult.Error;
+            }
+        }
+
+        protected override bool TryGetOverrideMessage(GitCommit commit, [NotNullWhen(true)] out string? message)
+        {
+            if (m_OverrideMessages.Value.TryGetValue(commit.Id, out message))
+            {
+                m_Logger.LogInformation($"Commit message for commit '{commit.Id}' was overridden through filesystem. Using message from filesystem instead of commit message.");
+                return true;
+            }
+
+            return false;
+        }
+
+
+        private IReadOnlyDictionary<GitId, string> LoadOverrideMessages()
+        {
+            var sourceDirectoryPath = Path.IsPathRooted(m_Configuration.MessageOverrides.SourceDirectoryPath)
+                ? m_Configuration.MessageOverrides.SourceDirectoryPath
+                : Path.Combine(m_Configuration.RepositoryPath, m_Configuration.MessageOverrides.SourceDirectoryPath);
+
+            if (!Directory.Exists(sourceDirectoryPath))
+            {
+                m_Logger.LogDebug($"Commit message override directory '{sourceDirectoryPath}' does not exist, skipping loading of overrides.");
+                return new Dictionary<GitId, string>();
+            }
+
+            m_Logger.LogDebug($"Loading commit message overrides from '{sourceDirectoryPath}'");
+            var overrideMessages = new Dictionary<GitId, string>();
+            foreach (var file in Directory.GetFiles(sourceDirectoryPath))
+            {
+                var name = Path.GetFileName(file);
+                var commit = m_Repository.TryGetCommit(name);
+                if (commit is null)
+                {
+                    m_Logger.LogWarning($"Ignoring file '{name}' from commit message override directory '{sourceDirectoryPath}' because no matching commit was found");
+                    continue;
+                }
+
+                if (overrideMessages.ContainsKey(commit.Id))
+                {
+                    m_Logger.LogError($"Found multiple commit message override files for commit '{commit.Id}' in directory '{sourceDirectoryPath}'");
+                    throw new DuplicateOverrideMessageException();
+                }
+
+                m_Logger.LogDebug($"Successfully loaded commit message override for commit '{commit.Id}'from file '{name}'");
+                overrideMessages.Add(commit.Id, File.ReadAllText(file));
+            }
+
+            return overrideMessages;
+        }
+    }
+}

--- a/src/ChangeLog/Tasks/LoadMessageOverridesFromGitNotesTask.cs
+++ b/src/ChangeLog/Tasks/LoadMessageOverridesFromGitNotesTask.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Grynwald.ChangeLog.Configuration;
+using Grynwald.ChangeLog.Git;
+using Grynwald.ChangeLog.Pipeline;
+using Microsoft.Extensions.Logging;
+
+namespace Grynwald.ChangeLog.Tasks
+{
+    [AfterTask(typeof(LoadCommitsTask))]
+    [BeforeTask(typeof(ParseCommitsTask))]
+    internal sealed class LoadMessageOverridesFromGitNotesTask : LoadMessageOverridesTask
+    {
+        private readonly ILogger<LoadMessageOverridesFromGitNotesTask> m_Logger;
+        private readonly ChangeLogConfiguration m_Configuration;
+        private readonly IGitRepository m_Repository;
+
+
+        public LoadMessageOverridesFromGitNotesTask(ILogger<LoadMessageOverridesFromGitNotesTask> logger, ChangeLogConfiguration configuration, IGitRepository repository) : base(logger)
+        {
+            m_Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            m_Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            m_Repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        }
+
+
+        protected override bool TryGetOverrideMessage(GitCommit commit, [NotNullWhen(true)] out string? message)
+        {
+            var notes = m_Repository
+                .GetNotes(commit.Id)
+                .Where(n => n.Namespace == m_Configuration.MessageOverrides.GitNotesNamespace);
+
+            if (notes.Any())
+            {
+                m_Logger.LogInformation($"Commit message for commit '{commit.Id}' was overridden through git-notes. Using message from git-notes instead of commit message.");
+                message = notes.Single().Message;
+                return true;
+            }
+
+            message = default;
+            return false;
+        }
+    }
+}

--- a/src/ChangeLog/Tasks/LoadMessageOverridesTask.cs
+++ b/src/ChangeLog/Tasks/LoadMessageOverridesTask.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Grynwald.ChangeLog.Configuration;
 using Grynwald.ChangeLog.Git;
 using Grynwald.ChangeLog.Model;
 using Grynwald.ChangeLog.Pipeline;
@@ -9,19 +8,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Grynwald.ChangeLog.Tasks
 {
-    [AfterTask(typeof(LoadCommitsTask))]
-    [BeforeTask(typeof(ParseCommitsTask))]
-    internal sealed class LoadMessageOverridesTask : SynchronousChangeLogTask
+    internal abstract class LoadMessageOverridesTask : SynchronousChangeLogTask
     {
         private readonly ILogger<LoadMessageOverridesTask> m_Logger;
-        private readonly ChangeLogConfiguration m_Configuration;
-        private readonly IGitRepository m_Repository;
 
-        public LoadMessageOverridesTask(ILogger<LoadMessageOverridesTask> logger, ChangeLogConfiguration configuration, IGitRepository repository)
+
+        public LoadMessageOverridesTask(ILogger<LoadMessageOverridesTask> logger)
         {
             m_Logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            m_Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            m_Repository = repository ?? throw new ArgumentNullException(nameof(repository));
         }
 
 
@@ -32,8 +26,6 @@ namespace Grynwald.ChangeLog.Tasks
                 return ChangeLogTaskResult.Skipped;
             }
 
-            // TODO: Check here if message overrides are enabled?? Or handle that in the composition root?           
-
             m_Logger.LogInformation("Checking for commit message overrides");
 
             foreach (var versionChangeLog in changelog.ChangeLogs)
@@ -42,8 +34,6 @@ namespace Grynwald.ChangeLog.Tasks
                 {
                     if (TryGetOverrideMessage(commit, out var overrideMessage))
                     {
-                        m_Logger.LogInformation($"Commit message for commit '{commit.Id}' was overridden through git-notes. Using message from git-notes instead of commit message.");
-
                         var newCommit = commit.WithCommitMessage(overrideMessage);
 
                         versionChangeLog.Remove(commit);
@@ -56,20 +46,6 @@ namespace Grynwald.ChangeLog.Tasks
         }
 
 
-        private bool TryGetOverrideMessage(GitCommit commit, [NotNullWhen(true)] out string? message)
-        {
-            var notes = m_Repository
-                .GetNotes(commit.Id)
-                .Where(n => n.Namespace == m_Configuration.MessageOverrides.GitNotesNamespace);
-
-            if (notes.Any())
-            {
-                message = notes.Single().Message;
-                return true;
-            }
-
-            message = default;
-            return false;
-        }
+        protected abstract bool TryGetOverrideMessage(GitCommit commit, [NotNullWhen(true)] out string? message);
     }
 }


### PR DESCRIPTION
Extend the "Commit Message Overrides" with the option to use files instead of git notes.

Documentation link (after merge): https://github.com/ap0llo/changelog/blob/master/docs/message-overrides.md