### PR TITLE
docs: Remove duplication in templates

### DIFF
--- a/docs/configuration/settings/_partials/settings-table.allowed-values.md.scriban
+++ b/docs/configuration/settings/_partials/settings-table.allowed-values.md.scriban
@@ -1,0 +1,12 @@
+{{~ if (configuration.get_allowed_values($.settings_key) | array.size) > 0 ~}}
+<tr>
+    <td><b>Allowed values</b></td>
+    <td>
+        <ul>
+            {{~ for item in configuration.get_allowed_values($.settings_key) ~}}
+            <li><code>{{ item }}</code></li>
+            {{~ end ~}}
+        </ul>
+    </td>
+</tr>
+{{~ end ~}}

--- a/docs/configuration/settings/_partials/settings-table.commandline-parameter.md.scriban
+++ b/docs/configuration/settings/_partials/settings-table.commandline-parameter.md.scriban
@@ -1,0 +1,10 @@
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+    {{~ if configuration.get_commandline_parameter($.settings_key) ~}}
+        <code>{{ configuration.get_commandline_parameter($.settings_key) | html.escape }}</code>
+    {{~ else ~}}
+        -
+    {{~ end ~}}
+    </td>
+</tr>

--- a/docs/configuration/settings/_partials/settings-table.default-value.md.scriban
+++ b/docs/configuration/settings/_partials/settings-table.default-value.md.scriban
@@ -1,0 +1,10 @@
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+    {{~ if configuration.get_scalar($.settings_key) ~}}
+        <code>{{ configuration.get_scalar($.settings_key) | html.escape }}</code>
+    {{~ else ~}}
+        -
+    {{~ end ~}}
+    </td>
+</tr>

--- a/docs/configuration/settings/_partials/settings-table.environment-variable.md.scriban
+++ b/docs/configuration/settings/_partials/settings-table.environment-variable.md.scriban
@@ -1,0 +1,11 @@
+{{~
+    environment_variable_name = configuration.get_environment_variable_name($.settings_key)
+~}}
+<tr>
+    <td><b>Environment Variable</b></td>
+    {{~ if environment_variable_name ~}}
+    <td><code>{{ environment_variable_name }}</code></td>
+    {{~ else ~}}
+    <td>-</td>
+    {{~ end ~}}
+</tr>

--- a/docs/configuration/settings/_partials/settings-table.md.scriban
+++ b/docs/configuration/settings/_partials/settings-table.md.scriban
@@ -1,0 +1,8 @@
+<table>
+{{ include("settings-table.name.md.scriban", settings_key: $.settings_key) }}
+{{ include("settings-table.environment-variable.md.scriban", settings_key: $.settings_key) }}
+{{ include("settings-table.commandline-parameter.md.scriban", settings_key: $.settings_key) }}
+{{ include("settings-table.default-value.md.scriban", settings_key: $.settings_key) }}
+{{ include("settings-table.allowed-values.md.scriban", settings_key: $.settings_key) }}
+{{ include("settings-table.version-support.md.scriban", settings_key: $.settings_key, version_support: $.version_support) }}
+</table>

--- a/docs/configuration/settings/_partials/settings-table.name.md.scriban
+++ b/docs/configuration/settings/_partials/settings-table.name.md.scriban
@@ -1,0 +1,4 @@
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>{{ $.settings_key }}</code></td>
+</tr>

--- a/docs/configuration/settings/_partials/settings-table.version-support.md.scriban
+++ b/docs/configuration/settings/_partials/settings-table.version-support.md.scriban
@@ -1,0 +1,4 @@
+<tr>
+    <td><b>Version Support</b></td>
+    <td>{{ $.version_support }}</td>
+</tr>

--- a/docs/configuration/settings/current-version.md
+++ b/docs/configuration/settings/current-version.md
@@ -8,30 +8,31 @@
 # Current Version Setting
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:currentVersion</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__CURRENTVERSION</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            <code>currentVersion</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:currentVersion</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__CURRENTVERSION</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        <code>currentVersion</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.1+</td>
+</tr>
 </table>
 
 By default, versions are only read from a git repository's tags and only tagged versions are included in the change log.

--- a/docs/configuration/settings/current-version.md.scriban
+++ b/docs/configuration/settings/current-version.md.scriban
@@ -1,42 +1,6 @@
-{{~
-    settingskey = "changelog:currentVersion"
-~}}
 # Current Version Setting
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{ settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-        {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:currentVersion", version_support: "0.1+") }}
 
 By default, versions are only read from a git repository's tags and only tagged versions are included in the change log.
 To include the currently checked out commit (the repository HEAD), you can specify the current version.

--- a/docs/configuration/settings/default-template.md
+++ b/docs/configuration/settings/default-template.md
@@ -12,30 +12,31 @@ This pages describes the configuration options of the [Default Template](../../t
 ## Normalize References
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:template:default:normalizeReferences</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__TEMPLATE__DEFAULT__NORMALIZEREFERENCES</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>true</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:template:default:normalizeReferences</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__TEMPLATE__DEFAULT__NORMALIZEREFERENCES</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>true</code>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The *Normalize References* settings controls whether references in the change log are normalized when using the default template.
@@ -44,32 +45,32 @@ See [Reference Normalization](../../auto-references.md#normalization) for detail
 
 ## Custom Directory
 
-
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:template:default:customDirectory</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__TEMPLATE__DEFAULT__CUSTOMDIRECTORY</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:template:default:customDirectory</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__TEMPLATE__DEFAULT__CUSTOMDIRECTORY</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.4+</td>
+</tr>
 </table>
 
 The "Custom Directory" settings allows specifying the path for a directory that contains customizations for the template.

--- a/docs/configuration/settings/default-template.md.scriban
+++ b/docs/configuration/settings/default-template.md.scriban
@@ -3,44 +3,8 @@
 This pages describes the configuration options of the [Default Template](../../templates/default.md).
 
 ## Normalize References
-{{~
-    settingskey = "changelog:template:default:normalizeReferences"
-~}}
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:template:default:normalizeReferences", version_support: "0.3+") }}
 
 The *Normalize References* settings controls whether references in the change log are normalized when using the default template.
 
@@ -48,44 +12,7 @@ See [Reference Normalization](../../auto-references.md#normalization) for detail
 
 ## Custom Directory
 
-{{~
-    settingskey = "changelog:template:default:customDirectory"
-~}}
-
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:template:default:customDirectory", version_support: "0.4+") }}
 
 The "Custom Directory" settings allows specifying the path for a directory that contains customizations for the template.
 For details see [Customization (Default Template)](../../templates/default.md#customization)

--- a/docs/configuration/settings/entry-types.md
+++ b/docs/configuration/settings/entry-types.md
@@ -28,9 +28,7 @@ For documentation on the "Entry Types" setting in version 0.2, see [Entry Types 
     </tr>
     <tr>
         <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
+        <td>-</td>
     </tr>
     <tr>
         <td><b>Default value</b></td>
@@ -101,9 +99,7 @@ The following example shows how to define a display name for entries of type `do
     </tr>
     <tr>
         <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
+        <td>-</td>
     </tr>
     <tr>
         <td><b>Default value</b></td>

--- a/docs/configuration/settings/entry-types.md.scriban
+++ b/docs/configuration/settings/entry-types.md.scriban
@@ -24,13 +24,7 @@ For documentation on the "Entry Types" setting in version 0.2, see [Entry Types 
     </tr>
     <tr>
         <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
+        <td>-</td>
     </tr>
     <tr>
         <td><b>Default value</b></td>
@@ -94,13 +88,7 @@ The following example shows how to define a display name for entries of type `do
     </tr>
     <tr>
         <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-        <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
+        <td>-</td>
     </tr>
     <tr>
         <td><b>Default value</b></td>

--- a/docs/configuration/settings/filter.md
+++ b/docs/configuration/settings/filter.md
@@ -8,24 +8,24 @@
 # Filter Setting
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:filter</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>{
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:filter</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td>-</td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>{
   &quot;include&quot;: [
     {
       &quot;type&quot;: &quot;feat&quot;,
@@ -38,12 +38,13 @@
   ],
   &quot;exclude&quot;: []
 }</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The "Filter" setting controls which entries of a change log are included in the output.

--- a/docs/configuration/settings/filter.md.scriban
+++ b/docs/configuration/settings/filter.md.scriban
@@ -1,42 +1,6 @@
-{{~
-    settingskey = "changelog:filter"
-~}}
 # Filter Setting
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:filter", version_support: "0.3+") }}
 
 The "Filter" setting controls which entries of a change log are included in the output.
 

--- a/docs/configuration/settings/footers.md
+++ b/docs/configuration/settings/footers.md
@@ -28,9 +28,7 @@ For documentation on the "Footers" setting in version 0.2, see [Footers Setting 
     </tr>
     <tr>
         <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
+        <td>-</td>
     </tr>
     <tr>
         <td><b>Default value</b></td>

--- a/docs/configuration/settings/footers.md.scriban
+++ b/docs/configuration/settings/footers.md.scriban
@@ -24,13 +24,7 @@ For documentation on the "Footers" setting in version 0.2, see [Footers Setting 
     </tr>
     <tr>
         <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-        <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
+        <td>-</td>
     </tr>
     <tr>
         <td><b>Default value</b></td>

--- a/docs/configuration/settings/github-integration.md
+++ b/docs/configuration/settings/github-integration.md
@@ -19,30 +19,31 @@ See also [Integrations - GitHub](../../integrations/github.md).
 ## GitHub Access Token
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:github:accessToken</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITHUB__ACCESSTOKEN</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            <code>githubAccessToken</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:github:accessToken</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITHUB__ACCESSTOKEN</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        <code>githubAccessToken</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.1+</td>
+</tr>
 </table>
 
 The *GitHub Access Token* setting configures the access token to use for
@@ -55,30 +56,31 @@ accessing the GitHub API when the GitHub integration is enabled.
 ## GitHub Remote Name
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:github:remoteName</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITHUB__REMOTENAME</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>origin</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:github:remoteName</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITHUB__REMOTENAME</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>origin</code>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The GitHub integration requires information about the repository on GitHub in order to function.
@@ -96,30 +98,31 @@ For details on how the remote URL is parsed, see [Integrations - GitHub](../../i
 ## GitHub Host
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:github:host</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITHUB__HOST</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:github:host</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITHUB__HOST</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The *GitHub Host* setting specifies the host-name of the GitHub server to communicate with.
@@ -131,30 +134,31 @@ When no host name is specified (default behavior), ChangeLog will attempt to det
 ## GitHub Repository Owner
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:github:owner</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITHUB__OWNER</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:github:owner</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITHUB__OWNER</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The *GitHub Repository Owner* setting specifies the name of the owner (user or organization) of the GitHub repository to use .
@@ -164,30 +168,31 @@ When no owner is specified (default behavior), ChangeLog will attempt to determi
 ## GitHub Repository Name
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:github:repository</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITHUB__REPOSITORY</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:github:repository</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITHUB__REPOSITORY</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The *GitHub Repository Name* setting specifies the name of the GitHub repository to use.

--- a/docs/configuration/settings/github-integration.md.scriban
+++ b/docs/configuration/settings/github-integration.md.scriban
@@ -1,10 +1,3 @@
-{{~
-    settingskey_accesstoken = "changelog:integrations:github:accessToken"
-    settingskey_remotename = "changelog:integrations:github:remoteName"
-    settingskey_host = "changelog:integrations:github:host"
-    settingskey_owner = "changelog:integrations:github:owner"
-    settingskey_repository = "changelog:integrations:github:repository"
-~}}
 # GitHub Integration Settings
 
 The *GitHub Integration* settings control the behavior of the GitHub integration.
@@ -18,40 +11,7 @@ See also [Integrations - GitHub](../../integrations/github.md).
 
 ## GitHub Access Token
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_accesstoken}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_accesstoken }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_accesstoken ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_accesstoken | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_accesstoken ~}}
-            <code>{{configuration.get_scalar settingskey_accesstoken | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:github:accessToken", version_support: "0.1+") }}
 
 The *GitHub Access Token* setting configures the access token to use for
 accessing the GitHub API when the GitHub integration is enabled.
@@ -62,40 +22,7 @@ accessing the GitHub API when the GitHub integration is enabled.
 
 ## GitHub Remote Name
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_remotename}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_remotename }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_remotename ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_remotename | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_remotename ~}}
-            <code>{{configuration.get_scalar settingskey_remotename | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:github:remoteName", version_support: "0.3+") }}
 
 The GitHub integration requires information about the repository on GitHub in order to function.
 This information includes the host (typically `github.com` but might differ for GitHub Enterprise servers), the name of the repository owner (GitHub user or organization) as well as the name of the repository.
@@ -111,40 +38,7 @@ For details on how the remote URL is parsed, see [Integrations - GitHub](../../i
 
 ## GitHub Host
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_host}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_host }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_host ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_host | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_host ~}}
-            <code>{{configuration.get_scalar settingskey_host | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:github:host", version_support: "0.3+") }}
 
 The *GitHub Host* setting specifies the host-name of the GitHub server to communicate with.
 
@@ -154,40 +48,7 @@ When no host name is specified (default behavior), ChangeLog will attempt to det
 
 ## GitHub Repository Owner
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_owner}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_owner }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_owner ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_owner | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_owner ~}}
-            <code>{{configuration.get_scalar settingskey_owner | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:github:owner", version_support: "0.3+") }}
 
 The *GitHub Repository Owner* setting specifies the name of the owner (user or organization) of the GitHub repository to use .
 
@@ -195,40 +56,7 @@ When no owner is specified (default behavior), ChangeLog will attempt to determi
 
 ## GitHub Repository Name
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_repository}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_repository }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_repository ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_repository | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_repository ~}}
-            <code>{{configuration.get_scalar settingskey_repository | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:github:repository", version_support: "0.3+") }}
 
 The *GitHub Repository Name* setting specifies the name of the GitHub repository to use.
 

--- a/docs/configuration/settings/githubrelease-template.md
+++ b/docs/configuration/settings/githubrelease-template.md
@@ -12,30 +12,31 @@ This pages describes the configuration options of the [GitHub Release Template](
 ## Normalize References
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:template:githubrelease:normalizeReferences</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__TEMPLATE__GITHUBRELEASE__NORMALIZEREFERENCES</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>true</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:template:githubrelease:normalizeReferences</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__TEMPLATE__GITHUBRELEASE__NORMALIZEREFERENCES</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>true</code>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The *Normalize References* settings controls whether references in the change log are normalized when using the GitHubRelease template.
@@ -44,37 +45,36 @@ See [Reference Normalization](../../auto-references.md#normalization) for detail
 
 ## Custom Directory
 
-
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:template:githubRelease:customDirectory</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__TEMPLATE__GITHUBRELEASE__CUSTOMDIRECTORY</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:template:githubRelease:customDirectory</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__TEMPLATE__GITHUBRELEASE__CUSTOMDIRECTORY</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.4+</td>
+</tr>
 </table>
 
 The "Custom Directory" settings allows specifying the path for a directory that contains customizations for the template.
 For details see [Customization (GitHub Release Template)](../../templates/githubrelease.md#customization)
-
 
 ## See Also
 

--- a/docs/configuration/settings/githubrelease-template.md.scriban
+++ b/docs/configuration/settings/githubrelease-template.md.scriban
@@ -3,44 +3,8 @@
 This pages describes the configuration options of the [GitHub Release Template](../../templates/githubrelease.md).
 
 ## Normalize References
-{{~
-    settingskey = "changelog:template:githubrelease:normalizeReferences"
-~}}
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:template:githubrelease:normalizeReferences", version_support: "0.3+") }}
 
 The *Normalize References* settings controls whether references in the change log are normalized when using the GitHubRelease template.
 
@@ -48,48 +12,10 @@ See [Reference Normalization](../../auto-references.md#normalization) for detail
 
 ## Custom Directory
 
-{{~
-    settingskey = "changelog:template:githubRelease:customDirectory"
-~}}
-
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:template:githubRelease:customDirectory", version_support: "0.4+") }}
 
 The "Custom Directory" settings allows specifying the path for a directory that contains customizations for the template.
 For details see [Customization (GitHub Release Template)](../../templates/githubrelease.md#customization)
-
 
 ## See Also
 

--- a/docs/configuration/settings/gitlab-integration.md
+++ b/docs/configuration/settings/gitlab-integration.md
@@ -19,30 +19,31 @@ See also [Integrations - GitLab](../../integrations/gitlab.md).
 ## GitLab Access Token
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:gitlab:accessToken</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITLAB__ACCESSTOKEN</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            <code>gitlabAccessToken</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:gitlab:accessToken</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITLAB__ACCESSTOKEN</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        <code>gitlabAccessToken</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.1+</td>
+</tr>
 </table>
 
 The *GitLab Access Token* setting configures the access token to use for
@@ -55,30 +56,31 @@ accessing the GitLab  API when the GitLab integration is enabled.
 ## GitLab Remote Name
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:gitlab:remoteName</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITLAB__REMOTENAME</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>origin</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:gitlab:remoteName</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITLAB__REMOTENAME</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>origin</code>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The GitLab integration requires information about the repository on GitLab in order to function.
@@ -96,30 +98,31 @@ For details on how the remote URL is parsed, see [Integrations - GitLab](../../i
 ## GitLab Host
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:gitlab:host</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITLAB__HOST</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:gitlab:host</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITLAB__HOST</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The *GitLab Host* setting specifies the host-name of the GitLab server to communicate with.
@@ -129,30 +132,31 @@ When no host name is specified (default behavior), ChangeLog will attempt to det
 ## GitLab Namespace
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:gitlab:namespace</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITLAB__NAMESPACE</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:gitlab:namespace</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITLAB__NAMESPACE</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The *GitLab Namespace* setting specifies the namespace of the GitLab project to use.
@@ -163,30 +167,31 @@ When no namespace is specified (default behavior), ChangeLog will attempt to det
 ## GitLab Project Name
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:gitlab:project</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__GITLAB__PROJECT</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:gitlab:project</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__GITLAB__PROJECT</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The *GitLab Project Name* setting specifies the name of the GitLab project to use.

--- a/docs/configuration/settings/gitlab-integration.md.scriban
+++ b/docs/configuration/settings/gitlab-integration.md.scriban
@@ -1,10 +1,3 @@
-{{~
-    settingskey_accesstoken = "changelog:integrations:gitlab:accessToken"
-    settingskey_remotename = "changelog:integrations:gitlab:remoteName"
-    settingskey_host = "changelog:integrations:gitlab:host"
-    settingskey_namespace = "changelog:integrations:gitlab:namespace"
-    settingskey_project = "changelog:integrations:gitlab:project"
-~}}
 # GitLab Integration Settings
 
 The *GitLab Integration* settings control the behavior of the GitLab integration.
@@ -18,40 +11,7 @@ See also [Integrations - GitLab](../../integrations/gitlab.md).
 
 ## GitLab Access Token
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_accesstoken}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_accesstoken }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_accesstoken ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_accesstoken | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_accesstoken ~}}
-            <code>{{configuration.get_scalar settingskey_accesstoken | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:gitlab:accessToken", version_support: "0.1+") }}
 
 The *GitLab Access Token* setting configures the access token to use for
 accessing the GitLab  API when the GitLab integration is enabled.
@@ -62,40 +22,7 @@ accessing the GitLab  API when the GitLab integration is enabled.
 
 ## GitLab Remote Name
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_remotename}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_remotename }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_remotename ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_remotename | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_remotename ~}}
-            <code>{{configuration.get_scalar settingskey_remotename | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:gitlab:remoteName", version_support: "0.3+") }}
 
 The GitLab integration requires information about the repository on GitLab in order to function.
 This information includes the host name of the GitLab server, the namespace of the project (GitLab user or group/subgroup) as well as the name of the project.
@@ -111,40 +38,7 @@ For details on how the remote URL is parsed, see [Integrations - GitLab](../../i
 
 ## GitLab Host
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_host}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_host }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_host ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_host | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_host ~}}
-            <code>{{configuration.get_scalar settingskey_host | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:gitlab:host", version_support: "0.3+") }}
 
 The *GitLab Host* setting specifies the host-name of the GitLab server to communicate with.
 
@@ -152,40 +46,7 @@ When no host name is specified (default behavior), ChangeLog will attempt to det
 
 ## GitLab Namespace
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_namespace}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_namespace }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_namespace ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_namespace | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_namespace ~}}
-            <code>{{configuration.get_scalar settingskey_namespace | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:gitlab:namespace", version_support: "0.3+") }}
 
 The *GitLab Namespace* setting specifies the namespace of the GitLab project to use.
 This can be a GitLab user name or the name of a group/subgroup.
@@ -194,40 +55,7 @@ When no namespace is specified (default behavior), ChangeLog will attempt to det
 
 ## GitLab Project Name
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey_project}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey_project }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey_project ~}}
-            <code>{{configuration.get_commandline_parameter settingskey_project | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey_project ~}}
-            <code>{{configuration.get_scalar settingskey_project | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:integrations:gitlab:project", version_support: "0.3+") }}
 
 The *GitLab Project Name* setting specifies the name of the GitLab project to use.
 

--- a/docs/configuration/settings/gitlabrelease-template.md
+++ b/docs/configuration/settings/gitlabrelease-template.md
@@ -12,30 +12,31 @@ This pages describes the configuration options of the [GitHub Release Template](
 ## Normalize References
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:template:gitlabrelease:normalizeReferences</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__TEMPLATE__GITLABRELEASE__NORMALIZEREFERENCES</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>true</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:template:gitlabrelease:normalizeReferences</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__TEMPLATE__GITLABRELEASE__NORMALIZEREFERENCES</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>true</code>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.3+</td>
+</tr>
 </table>
 
 The *Normalize References* settings controls whether references in the change log are normalized when using the GitLabRelease template.
@@ -44,37 +45,36 @@ See [Reference Normalization](../../auto-references.md#normalization) for detail
 
 ## Custom Directory
 
-
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:template:gitlabrelease:customDirectory</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__TEMPLATE__GITLABRELEASE__CUSTOMDIRECTORY</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:template:gitlabrelease:customDirectory</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__TEMPLATE__GITLABRELEASE__CUSTOMDIRECTORY</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.4+</td>
+</tr>
 </table>
 
 The "Custom Directory" settings allows specifying the path for a directory that contains customizations for the template.
 For details see [Customization (GitLab Release Template)](../../templates/gitlabrelease.md#customization)
-
 
 ## See Also
 

--- a/docs/configuration/settings/gitlabrelease-template.md.scriban
+++ b/docs/configuration/settings/gitlabrelease-template.md.scriban
@@ -3,44 +3,8 @@
 This pages describes the configuration options of the [GitHub Release Template](../../templates/gitlabrelease.md).
 
 ## Normalize References
-{{~
-    settingskey = "changelog:template:gitlabrelease:normalizeReferences"
-~}}
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.3+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:template:gitlabrelease:normalizeReferences", version_support: "0.3+") }}
 
 The *Normalize References* settings controls whether references in the change log are normalized when using the GitLabRelease template.
 
@@ -48,48 +12,10 @@ See [Reference Normalization](../../auto-references.md#normalization) for detail
 
 ## Custom Directory
 
-{{~
-    settingskey = "changelog:template:gitlabrelease:customDirectory"
-~}}
-
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:template:gitlabrelease:customDirectory", version_support: "0.4+") }}
 
 The "Custom Directory" settings allows specifying the path for a directory that contains customizations for the template.
 For details see [Customization (GitLab Release Template)](../../templates/gitlabrelease.md#customization)
-
 
 ## See Also
 

--- a/docs/configuration/settings/html-template.md
+++ b/docs/configuration/settings/html-template.md
@@ -12,30 +12,31 @@ This pages describes the configuration options of the [Html Template](../../temp
 ## Normalize References
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:template:html:normalizeReferences</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__TEMPLATE__HTML__NORMALIZEREFERENCES</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>true</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:template:html:normalizeReferences</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__TEMPLATE__HTML__NORMALIZEREFERENCES</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>true</code>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.4+</td>
+</tr>
 </table>
 
 The *Normalize References* settings controls whether references in the change log are normalized when using the Html template.
@@ -44,32 +45,32 @@ See [Reference Normalization](../../auto-references.md#normalization) for detail
 
 ## Custom Directory
 
-
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:template:html:customDirectory</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__TEMPLATE__HTML__CUSTOMDIRECTORY</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:template:html:customDirectory</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__TEMPLATE__HTML__CUSTOMDIRECTORY</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.4+</td>
+</tr>
 </table>
 
 The "Custom Directory" settings allows specifying the path for a directory that contains customizations for the template.

--- a/docs/configuration/settings/html-template.md.scriban
+++ b/docs/configuration/settings/html-template.md.scriban
@@ -3,44 +3,8 @@
 This pages describes the configuration options of the [Html Template](../../templates/html.md).
 
 ## Normalize References
-{{~
-    settingskey = "changelog:template:html:normalizeReferences"
-~}}
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:template:html:normalizeReferences", version_support: "0.4+") }}
 
 The *Normalize References* settings controls whether references in the change log are normalized when using the Html template.
 
@@ -48,44 +12,7 @@ See [Reference Normalization](../../auto-references.md#normalization) for detail
 
 ## Custom Directory
 
-{{~
-    settingskey = "changelog:template:html:customDirectory"
-~}}
-
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.4+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:template:html:customDirectory", version_support: "0.4+") }}
 
 The "Custom Directory" settings allows specifying the path for a directory that contains customizations for the template.
 For details see [Customization (Html Template)](../../templates/html.md#customization)

--- a/docs/configuration/settings/integration-provider.md
+++ b/docs/configuration/settings/integration-provider.md
@@ -8,45 +8,46 @@
 # Integration Provider Setting
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:integrations:provider</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__INTEGRATIONS__PROVIDER</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            <code>integrationProvider</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>None</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Allowed values</b></td>
-        <td>
-            <ul>
-                <li><code>None</code></li>
-                <li><code>GitHub</code></li>
-                <li><code>GitLab</code></li>
-            </ul>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>
-            <ul>
-                <li>0.1+: Setting supported through environment variables and configuration file.</li>
-                <li>0.4+: Setting supported through environment variables, configuration file and commandline parameter.</li>
-            </ul>
-        </td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:integrations:provider</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__INTEGRATIONS__PROVIDER</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        <code>integrationProvider</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>None</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Allowed values</b></td>
+    <td>
+        <ul>
+            <li><code>None</code></li>
+            <li><code>GitHub</code></li>
+            <li><code>GitLab</code></li>
+        </ul>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>
+        <ul>
+            <li>0.1+: Setting supported through environment variables and configuration file.</li>
+            <li>0.4+: Setting supported through environment variables, configuration file and commandline parameter.</li>
+        </ul>
+    </td>
+</tr>
 </table>
 
 Sets the *Integration Provider* to use.

--- a/docs/configuration/settings/integration-provider.md.scriban
+++ b/docs/configuration/settings/integration-provider.md.scriban
@@ -1,56 +1,23 @@
+# Integration Provider Setting
 {{~
     settingskey = "changelog:integrations:provider"
 ~}}
-# Integration Provider Setting
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Allowed values</b></td>
-        <td>
-            <ul>
-                {{~ for item in (configuration.get_allowed_values settingskey) ~}}
-                <li><code>{{item}}</code></li>
-                {{~ end ~}}
-            </ul>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>
-            <ul>
-                <li>0.1+: Setting supported through environment variables and configuration file.</li>
-                <li>0.4+: Setting supported through environment variables, configuration file and commandline parameter.</li>
-            </ul>
-        </td>
-    </tr>
+{{ include("_partials/settings-table.name.md.scriban", settings_key: settingskey) }}
+{{ include("_partials/settings-table.environment-variable.md.scriban", settings_key: settingskey) }}
+{{ include("_partials/settings-table.commandline-parameter.md.scriban", settings_key: settingskey) }}
+{{ include("_partials/settings-table.default-value.md.scriban", settings_key: settingskey) }}
+{{ include("_partials/settings-table.allowed-values.md.scriban", settings_key: settingskey) }}
+<tr>
+    <td><b>Version Support</b></td>
+    <td>
+        <ul>
+            <li>0.1+: Setting supported through environment variables and configuration file.</li>
+            <li>0.4+: Setting supported through environment variables, configuration file and commandline parameter.</li>
+        </ul>
+    </td>
+</tr>
 </table>
 
 Sets the *Integration Provider* to use.

--- a/docs/configuration/settings/message-overrides.md
+++ b/docs/configuration/settings/message-overrides.md
@@ -11,107 +11,104 @@ Commit Message Override Settings control the behavior of the ["Commit Message Ov
 
 ## Enable Message Overrides
 
-
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:messageOverrides:enabled</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__MESSAGEOVERRIDES__ENABLED</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>true</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>1.0+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:messageOverrides:enabled</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__MESSAGEOVERRIDES__ENABLED</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>true</code>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>1.0+</td>
+</tr>
 </table>
 
 Enabled/disables the ["Commit Message Overrides" feature](../../message-overrides.md).
 
 ## Message Override Provider
 
-
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:messageOverrides:provider</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__MESSAGEOVERRIDES__PROVIDER</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>GitNotes</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Allowed values</b></td>
-        <td>
-            <ul>
-                <li><code>GitNotes</code></li>
-                <li><code>FileSystem</code></li>
-            </ul>
-        </td>
-    </tr>    
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>1.1+</td>
-    </tr>
-</table>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:messageOverrides:provider</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__MESSAGEOVERRIDES__PROVIDER</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>GitNotes</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Allowed values</b></td>
+    <td>
+        <ul>
+            <li><code>GitNotes</code></li>
+            <li><code>FileSystem</code></li>
+        </ul>
+    </td>
+</tr>
 
+<tr>
+    <td><b>Version Support</b></td>
+    <td>1.1+</td>
+</tr>
+</table>
 
 ## Git Notes Namespace
 
-
-
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:messageOverrides:gitNotesNamespace</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__MESSAGEOVERRIDES__GITNOTESNAMESPACE</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>changelog/message-overrides</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>1.0+</td>
-    </tr>
-</table>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:messageOverrides:gitNotesNamespace</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__MESSAGEOVERRIDES__GITNOTESNAMESPACE</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>changelog/message-overrides</code>
+    </td>
+</tr>
 
+<tr>
+    <td><b>Version Support</b></td>
+    <td>1.0+</td>
+</tr>
+</table>
 
 Configures the "git notes namespace" to search for override messages when the [provider](#message-override-provider) is set to `GitNotes`.
 
@@ -119,32 +116,32 @@ By default, override messages are read from the `changelog/message-overrides` na
 
 ## Source Directory Path
 
-
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:messageOverrides:sourceDirectoryPath</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__MESSAGEOVERRIDES__SOURCEDIRECTORYPATH</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>.config/changelog/message-overrides</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>1.1+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:messageOverrides:sourceDirectoryPath</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__MESSAGEOVERRIDES__SOURCEDIRECTORYPATH</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>.config/changelog/message-overrides</code>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>1.1+</td>
+</tr>
 </table>
 
 Sets the path of the directory to load message overrides from, if the [provider](#message-override-provider) is set to `FileSystem`.

--- a/docs/configuration/settings/message-overrides.md.scriban
+++ b/docs/configuration/settings/message-overrides.md.scriban
@@ -4,186 +4,25 @@ Commit Message Override Settings control the behavior of the ["Commit Message Ov
 
 ## Enable Message Overrides
 
-{{~
-    settingskey = "changelog:messageOverrides:enabled"
-~}}
-
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>1.0+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:messageOverrides:enabled", version_support: "1.0+") }}
 
 Enabled/disables the ["Commit Message Overrides" feature](../../message-overrides.md).
 
 ## Message Override Provider
 
-{{~
-    settingskey = "changelog:messageOverrides:provider"
-~}}
-
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Allowed values</b></td>
-        <td>
-            <ul>
-                {{~ for item in (configuration.get_allowed_values settingskey) ~}}
-                <li><code>{{item}}</code></li>
-                {{~ end ~}}
-            </ul>
-        </td>
-    </tr>    
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>1.1+</td>
-    </tr>
-</table>
-
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:messageOverrides:provider", version_support: "1.1+") }}
 
 ## Git Notes Namespace
 
-{{~
-    settingskey = "changelog:messageOverrides:gitNotesNamespace"
-~}}
-
-
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>1.0+</td>
-    </tr>
-</table>
-
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:messageOverrides:gitNotesNamespace", version_support: "1.0+") }}
 
 Configures the "git notes namespace" to search for override messages when the [provider](#message-override-provider) is set to `GitNotes`.
 
-By default, override messages are read from the `{{configuration.get_scalar settingskey | html.escape}}` namespace.
+By default, override messages are read from the `{{configuration.get_scalar("changelog:messageOverrides:gitNotesNamespace") | html.escape}}` namespace.
 
 ## Source Directory Path
 
-{{~
-    settingskey = "changelog:messageOverrides:sourceDirectoryPath"
-~}}
-
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>1.1+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:messageOverrides:sourceDirectoryPath", version_support: "1.1+") }}
 
 Sets the path of the directory to load message overrides from, if the [provider](#message-override-provider) is set to `FileSystem`.
 

--- a/docs/configuration/settings/output-path.md
+++ b/docs/configuration/settings/output-path.md
@@ -8,30 +8,31 @@
 # Output Path Setting
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:outputPath</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__OUTPUTPATH</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            <code>outputPath</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>changelog.md</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:outputPath</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__OUTPUTPATH</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        <code>outputPath</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>changelog.md</code>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.1+</td>
+</tr>
 </table>
 
 Specifies the output path for the generated change log.

--- a/docs/configuration/settings/output-path.md.scriban
+++ b/docs/configuration/settings/output-path.md.scriban
@@ -1,42 +1,6 @@
-{{~
-    settingskey = "changelog:outputPath"
-~}}
 # Output Path Setting
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:outputPath", version_support: "0.1+") }}
 
 Specifies the output path for the generated change log.
 

--- a/docs/configuration/settings/parser-mode.md
+++ b/docs/configuration/settings/parser-mode.md
@@ -8,39 +8,40 @@
 # Parser Mode Setting
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:parser:mode</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>Loose</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Allowed values</b></td>
-        <td>
-            <ul>
-                <li><code>Strict</code></li>
-                <li><code>Loose</code></li>
-            </ul>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.2+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:parser:mode</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__PARSER__MODE</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>Loose</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Allowed values</b></td>
+    <td>
+        <ul>
+            <li><code>Strict</code></li>
+            <li><code>Loose</code></li>
+        </ul>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.2+</td>
+</tr>
 </table>
 
 The "Parser Mode" setting controls how lenient the commit message parser treats commit messages.

--- a/docs/configuration/settings/parser-mode.md.scriban
+++ b/docs/configuration/settings/parser-mode.md.scriban
@@ -1,52 +1,6 @@
-{{~
-    settingskey = "changelog:parser:mode"
-~}}
 # Parser Mode Setting
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Allowed values</b></td>
-        <td>
-            <ul>
-                {{~ for item in (configuration.get_allowed_values settingskey) ~}}
-                <li><code>{{item}}</code></li>
-                {{~ end ~}}
-            </ul>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.2+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:parser:mode", version_support: "0.2+") }}
 
 The "Parser Mode" setting controls how lenient the commit message parser treats commit messages.
 

--- a/docs/configuration/settings/tag-patterns.md
+++ b/docs/configuration/settings/tag-patterns.md
@@ -8,33 +8,34 @@
 # Tag Patterns Setting
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:tagPatterns</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value (JSON)</b></td>
-        <td>
-            <code>[
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:tagPatterns</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td>-</td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        -
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>[
   &quot;^(?&lt;version&gt;\\d+\\.\\d+(\\.\\d+)?.*)&quot;,
   &quot;^v(?&lt;version&gt;\\d+\\.\\d+(\\.\\d+)?.*)&quot;
 ]</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.1+</td>
+</tr>
 </table>
 
 The *Tag Patterns* setting controls how versions are read from a git repository's tags.

--- a/docs/configuration/settings/tag-patterns.md.scriban
+++ b/docs/configuration/settings/tag-patterns.md.scriban
@@ -1,42 +1,6 @@
-{{~
-    settingskey = "changelog:tagPatterns"
-~}}
 # Tag Patterns Setting
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value (JSON)</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:tagPatterns", version_support: "0.1+") }}
 
 The *Tag Patterns* setting controls how versions are read from a git repository's tags.
 The setting defines a list of regular expressions that are used to extract the version from the tag name.

--- a/docs/configuration/settings/template-name.md
+++ b/docs/configuration/settings/template-name.md
@@ -8,41 +8,42 @@
 # Template Name Setting
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:template:name</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__TEMPLATE__NAME</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            <code>template</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            <code>Default</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Allowed values</b></td>
-        <td>
-            <ul>
-                <li><code>Default</code></li>
-                <li><code>GitLabRelease</code></li>
-                <li><code>GitHubRelease</code></li>
-                <li><code>Html</code></li>
-            </ul>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.2+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:template:name</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__TEMPLATE__NAME</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        <code>template</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        <code>Default</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Allowed values</b></td>
+    <td>
+        <ul>
+            <li><code>Default</code></li>
+            <li><code>GitLabRelease</code></li>
+            <li><code>GitHubRelease</code></li>
+            <li><code>Html</code></li>
+        </ul>
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.2+</td>
+</tr>
 </table>
 
 Sets the template to use for generating the change log.

--- a/docs/configuration/settings/template-name.md.scriban
+++ b/docs/configuration/settings/template-name.md.scriban
@@ -1,52 +1,6 @@
-{{~
-    settingskey = "changelog:template:name"
-~}}
 # Template Name Setting
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Allowed values</b></td>
-        <td>
-            <ul>
-                {{~ for item in (configuration.get_allowed_values settingskey) ~}}
-                <li><code>{{item}}</code></li>
-                {{~ end ~}}
-            </ul>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.2+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:template:name", version_support: "0.2+") }}
 
 Sets the template to use for generating the change log.
 For details see [Templates](../../templates/README.md).

--- a/docs/configuration/settings/version-range.md
+++ b/docs/configuration/settings/version-range.md
@@ -8,30 +8,31 @@
 # Version Range Setting
 
 <table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>changelog:versionRange</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>CHANGELOG__VERSIONRANGE</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-            <code>versionRange</code>
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            -
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
+<tr>
+    <td><b>Setting</b></td>
+    <td><code>changelog:versionRange</code></td>
+</tr>
+<tr>
+    <td><b>Environment Variable</b></td>
+    <td><code>CHANGELOG__VERSIONRANGE</code></td>
+</tr>
+<tr>
+    <td><b>Commandline Parameter</b></td>
+    <td>
+        <code>versionRange</code>
+    </td>
+</tr>
+<tr>
+    <td><b>Default value</b></td>
+    <td>
+        -
+    </td>
+</tr>
+
+<tr>
+    <td><b>Version Support</b></td>
+    <td>0.1+</td>
+</tr>
 </table>
 
 By default, **all versions** are included in the change log.

--- a/docs/configuration/settings/version-range.md.scriban
+++ b/docs/configuration/settings/version-range.md.scriban
@@ -1,42 +1,6 @@
-{{~
-    settingskey = "changelog:versionRange"
-~}}
 # Version Range Setting
 
-<table>
-    <tr>
-        <td><b>Setting</b></td>
-        <td><code>{{settingskey}}</code></td>
-    </tr>
-    <tr>
-        <td><b>Environment Variable</b></td>
-        <td><code>{{ configuration.get_environment_variable_name settingskey }}</code></td>
-    </tr>
-    <tr>
-        <td><b>Commandline Parameter</b></td>
-        <td>
-        {{~ if configuration.get_commandline_parameter settingskey ~}}
-            <code>{{configuration.get_commandline_parameter settingskey | html.escape}}</code>
-        {{~ else ~}}
-            -
-        {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Default value</b></td>
-        <td>
-            {{~ if configuration.get_scalar settingskey ~}}
-            <code>{{configuration.get_scalar settingskey | html.escape}}</code>
-            {{~ else ~}}
-            -
-            {{~ end ~}}
-        </td>
-    </tr>
-    <tr>
-        <td><b>Version Support</b></td>
-        <td>0.1+</td>
-    </tr>
-</table>
+{{ include("_partials/settings-table.md.scriban", settings_key: "changelog:versionRange", version_support: "0.1+") }}
 
 By default, **all versions** are included in the change log.
 To limit the versions to include, you can specify a version range using this setting.

--- a/utilities/docs/IO.cs
+++ b/utilities/docs/IO.cs
@@ -37,5 +37,16 @@ namespace docs
 
             return StringComparer.OrdinalIgnoreCase.Equals(extension, Path.GetExtension(path));
         }
+
+        public static bool IsScribanPartial(string path)
+        {
+            if (String.IsNullOrEmpty(path))
+                throw new ArgumentException($"'{nameof(path)}' cannot be null or empty", nameof(path));
+
+            var directoryPath = Path.GetDirectoryName(path);
+            var directoryName = Path.GetFileName(directoryPath);
+
+            return StringComparer.OrdinalIgnoreCase.Equals(directoryName, "_partials");
+        }
     }
 }

--- a/utilities/docs/Program.cs
+++ b/utilities/docs/Program.cs
@@ -60,7 +60,9 @@ namespace docs
 
             Console.WriteLine($"Generating documentation from templates");
 
-            var inputFiles = GetAllInputFiles(parameters).Where(x => IO.HasExtension(x, IO.FileExtensions.Scriban));
+            var inputFiles = GetAllInputFiles(parameters)
+                .Where(x => IO.HasExtension(x, IO.FileExtensions.Scriban))
+                .Where(x => !IO.IsScribanPartial(x));
 
             foreach (var inputPath in inputFiles)
             {
@@ -92,8 +94,10 @@ namespace docs
                 .AddColumn(new TableColumn("[u]RuleId[/]").LeftAligned())
                 .AddColumn(new TableColumn("[u]Message[/]").LeftAligned());
 
+            var inputFiles = GetAllInputFiles(parameters);
 
-            foreach (var path in GetAllInputFiles(parameters))
+
+            foreach (var path in inputFiles)
             {
                 var outputPath = Path.ChangeExtension(path, "").TrimEnd('.');
 

--- a/utilities/docs/Validation/TemplateOutputIsUpToDateRule.cs
+++ b/utilities/docs/Validation/TemplateOutputIsUpToDateRule.cs
@@ -16,6 +16,9 @@ namespace docs.Validation
             if (!IO.HasExtension(path, IO.FileExtensions.Scriban))
                 return;
 
+            if (IO.IsScribanPartial(path))
+                return;
+
             var outputPath = IO.GetTemplateOutputPath(path);
 
             if (File.Exists(outputPath))


### PR DESCRIPTION
Move the generation of tables providing information about a setting to a shared partial that is included in each document instead of duplicating the table definition for each setting.