### PR TITLE
feat: Allow changelog to run on newer versions of .NET by default

### DIFF
--- a/src/ChangeLog/runtimeconfig.template.json
+++ b/src/ChangeLog/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Enable setting to allow running changelog on newer versions of .NET if none of the supported runtimes are available.

This means - while currently, changelog supports .NET 6 and .NET 7 - it will use the .NET 8 or newer runtime when no version of .NET 6 or .NET 7 is installed.

See-Also: https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-2-1#roll-forward
