### PR TITLE
feat: Add support for using Markdown link syntax in footers

### DIFF
--- a/docs/auto-references.md
+++ b/docs/auto-references.md
@@ -17,10 +17,11 @@ The following types of references are supported:
 - [Change Log Entry References](#change-log-entry-references)
 - [GitHub References](./integrations/github.md#references)
 - [GitLab References](./integrations/gitlab.md#references)
+- [Markdown links](#markdown-links)
 
 ### Web Urls
 
-If a footer's value is va valid `http` or `https` url, the footer will be included in the generated change log as link.
+If a footer's value is a valid `http` or `https` url, the footer will be included in the generated change log as link.
 
 ### Commit References
 
@@ -88,7 +89,23 @@ This is the description of the second feature.
 See Also: [Implemented a new feature](implemented-a-new-feature)
 ```
 
-If no change log entry that matches a commit hash can be found, the footer vaöue is treated as [commit reference](#commit-references).
+If no change log entry that matches a commit hash can be found, the footer value is treated as [commit reference](#commit-references).
+
+### Markdown Links
+
+**Supported versions:** 1.3+
+
+If a footer's value is a valid [Markdown link](https://spec.commonmark.org/0.30/#links) which's destination is a `http` or `https` address, the footer's value will be replaced with a link with in the output.
+If the Markdown link does not specify a link text, the url will be used.
+
+#### Examples
+
+| Footer Value                       | Output (Markdown)                            | Output (HTML)                                           |
+|------------------------------------|----------------------------------------------|---------------------------------------------------------|
+| `[Link Text](https://example.com)` | `[Link Text](https://example.com)`           | `<a href="https://example.com">Link Text</a>`           |
+| `[](https://example.com)`          | `[https://example.com](https://example.com)` | `<a href="https://example.com">https://example.com</a>` |
+
+
 
 ## Normalization
 
@@ -119,3 +136,4 @@ For example, a footer `See-Also: cd73d01418587529acbae4233580b7ea0cc01819` will 
 - [Integrations](./integrations.md)
 - [GitHub Integration](./integrations/github.md)
 - [GitLab Integration](./integrations/gitlab.md)
+- [Links (CommonMark Spec, version 0.30)](https://spec.commonmark.org/0.30/#links)

--- a/src/ChangeLog.Test/Tasks/ParseMarkdownWebLinksTaskTest.cs
+++ b/src/ChangeLog.Test/Tasks/ParseMarkdownWebLinksTaskTest.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Grynwald.ChangeLog.Model;
+using Grynwald.ChangeLog.Model.Text;
+using Grynwald.ChangeLog.Pipeline;
+using Grynwald.ChangeLog.Tasks;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Grynwald.ChangeLog.Test.Tasks
+{
+    /// <summary>
+    /// Tests for <see cref="ParseMarkdownWebLinksTask"/>
+    /// </summary>
+    public class ParseMarkdownWebLinksTaskTest
+    {
+        private readonly ILogger<ParseMarkdownWebLinksTask> m_Logger;
+
+
+        public ParseMarkdownWebLinksTaskTest(ITestOutputHelper testOutputHelper)
+        {
+            m_Logger = new XunitLogger<ParseMarkdownWebLinksTask>(testOutputHelper);
+        }
+
+
+        [Theory]
+        [InlineData("[Some Link](https://example.com)", "Some Link", "https://example.com")]
+        [InlineData("[](https://example.com)", "https://example.com/", "https://example.com")]
+        [InlineData(" [Some Link](http://example.com)", "Some Link", "http://example.com")]
+        [InlineData("[Some Link](http://example.com)  ", "Some Link", "http://example.com")]
+        public async Task Plain_text_footers_that_are_markdown_links_are_replaced_with_weblinks(string footerText, string expectedText, string expectedUrl)
+        {
+            // ARRANGE
+            var testData = new TestDataFactory();
+            var changeLog = new ApplicationChangeLog()
+            {
+                testData.GetSingleVersionChangeLog("1.2.3", entries: new[]
+                {
+                    testData.GetChangeLogEntry(footers: new[]
+                    {
+                        new ChangeLogEntryFooter(new("name"), new PlainTextElement(footerText))
+                    })
+                })
+            };
+
+            var sut = new ParseMarkdownWebLinksTask(m_Logger);
+
+            // ACT 
+            var result = await sut.RunAsync(changeLog);
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+            Assert.Collection(
+                changeLog.ChangeLogs.SelectMany(x => x.AllEntries).SelectMany(x => x.Footers),
+                footer =>
+                {
+                    var weblinkTextElement = Assert.IsType<WebLinkTextElement>(footer.Value);
+                    Assert.Equal(expectedText, weblinkTextElement.Text);
+                    Assert.Equal(new Uri(expectedUrl), weblinkTextElement.Uri);
+                }
+            );
+        }
+
+        [Theory]
+        [InlineData("[Some Link](not-a-url)")]
+        [InlineData("[Some Link](./relative/url)")]
+        [InlineData("[Some Link](ftp://example.com)")]
+        public async Task Markdown_links_that_are_not_web_links_are_ignored(string link)
+        {
+            // ARRANGE
+            var testData = new TestDataFactory();
+            var originalFooterValue = new PlainTextElement(link);
+            var changeLog = new ApplicationChangeLog()
+            {
+                testData.GetSingleVersionChangeLog("1.2.3", entries: new[]
+                {
+                    testData.GetChangeLogEntry(footers: new[]
+                    {
+                        new ChangeLogEntryFooter(new("name"), originalFooterValue)
+                    })
+                })
+            };
+
+            var sut = new ParseMarkdownWebLinksTask(m_Logger);
+
+            // ACT 
+            var result = await sut.RunAsync(changeLog);
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+            Assert.Collection(
+                changeLog.ChangeLogs.SelectMany(x => x.AllEntries).SelectMany(x => x.Footers),
+                footer => Assert.Same(originalFooterValue, footer.Value));
+        }
+
+        [Theory]
+        [InlineData("[Some Link](http://example.com)")]
+        public async Task Footers_that_are_not_plain_text_elements_are_ignored(string link)
+        {
+            // ARRANGE
+            var testData = new TestDataFactory();
+            var originalFooterValue = new CommitReferenceTextElement(link, TestGitIds.Id1);
+            var changeLog = new ApplicationChangeLog()
+            {
+                testData.GetSingleVersionChangeLog("1.2.3", entries: new[]
+                {
+                    testData.GetChangeLogEntry(footers: new[]
+                    {
+                        new ChangeLogEntryFooter(new("name"), originalFooterValue)
+                    })
+                })
+            };
+
+            var sut = new ParseMarkdownWebLinksTask(m_Logger);
+
+            // ACT 
+            var result = await sut.RunAsync(changeLog);
+
+            // ASSERT
+            Assert.Equal(ChangeLogTaskResult.Success, result);
+            Assert.Collection(
+                changeLog.ChangeLogs.SelectMany(x => x.AllEntries).SelectMany(x => x.Footers),
+                footer => Assert.Same(originalFooterValue, footer.Value));
+        }
+    }
+}

--- a/src/ChangeLog/Program.cs
+++ b/src/ChangeLog/Program.cs
@@ -122,6 +122,7 @@ namespace Grynwald.ChangeLog
                 containerBuilder.RegisterType<ResolveEntryReferencesTask>();
                 containerBuilder.RegisterType<AddCommitFooterTask>();
                 containerBuilder.RegisterType<ParseWebLinksTask>();
+                containerBuilder.RegisterType<ParseMarkdownWebLinksTask>();
                 containerBuilder.RegisterType<RenderTemplateTask>();
 
                 containerBuilder.RegisterIntegrations();
@@ -165,6 +166,7 @@ namespace Grynwald.ChangeLog
                         .AddTask<ParseCommitsTask>()
                         .AddTask<ParseCommitReferencesTask>()
                         .AddTask<ParseWebLinksTask>()
+                        .AddTask<ParseMarkdownWebLinksTask>()
                         .AddTask<FilterVersionsTask>()
                         .AddTask<FilterEntriesTask>()
                         .AddTask<ResolveEntryReferencesTask>()

--- a/src/ChangeLog/Tasks/ParseMarkdownWebLinksTask.cs
+++ b/src/ChangeLog/Tasks/ParseMarkdownWebLinksTask.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Grynwald.ChangeLog.Model;
+using Grynwald.ChangeLog.Model.Text;
+using Grynwald.ChangeLog.Pipeline;
+using Microsoft.Extensions.Logging;
+
+namespace Grynwald.ChangeLog.Tasks
+{
+    /// <summary>
+    /// Detects footer values that are web links using the Markdown link syntax (e.g. <c>[Some Link](https://example.com)</c>).
+    /// When a valid link is found, the footer's value (see <see cref="ChangeLogEntryFooter.Value"/>) is replaced with a <see cref="WebLinkTextElement"/>.
+    /// </summary>
+    /// <seealso href="https://spec.commonmark.org/0.30/#links">Links (CommonMark Spec, version 0.30)</seealso>
+    [AfterTask(typeof(ParseCommitsTask))]
+    [AfterTask(typeof(ParseWebLinksTask))]
+    [BeforeTask(typeof(RenderTemplateTask))]
+    internal sealed partial class ParseMarkdownWebLinksTask : SynchronousChangeLogTask
+    {
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("^\\s*\\[(?<text>.*)\\]\\((?<destination>.+)\\)\\s*$", RegexOptions.Singleline)]
+        private static partial Regex MarkdownLinkRegex();
+
+        // TODO: This field can be removed and usages can be replaced by a call to MarkdownLinkRegex(), once .NET 6 support is no removed
+        private static readonly Regex s_MarkdownLinkRegex = MarkdownLinkRegex();
+#else
+        private static readonly Regex s_MarkdownLinkRegex = new("^\\s*\\[(?<text>.*)\\]\\((?<destination>.+)\\)\\s*$", RegexOptions.Singleline);
+#endif
+
+        private readonly ILogger<ParseMarkdownWebLinksTask> m_Logger;
+
+
+        public ParseMarkdownWebLinksTask(ILogger<ParseMarkdownWebLinksTask> logger)
+        {
+            m_Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+
+        protected override ChangeLogTaskResult Run(ApplicationChangeLog changelog)
+        {
+            m_Logger.LogInformation("Checking for Markdown links in footers");
+
+            foreach (var changeLogEntry in changelog.ChangeLogs.SelectMany(x => x.AllEntries))
+            {
+                foreach (var footer in changeLogEntry.Footers)
+                {
+                    if (footer.Value is PlainTextElement plainText &&
+                        s_MarkdownLinkRegex.Match(plainText.Text) is { Success: true } match &&
+                        Uri.TryCreate(match.Groups["destination"].Value, UriKind.Absolute, out var destination) &&
+                        destination.IsWebLink())
+                    {
+                        m_Logger.LogDebug($"Detected Markdown link '{plainText.Text}' in footer for commit '{changeLogEntry.Commit.Id}'. Replacing footer value with web link");
+
+                        var linkText = match.Groups["text"].Value;
+
+                        // If link text is empty, e.g. "[](https://example.com", use the destination as text
+                        if (String.IsNullOrWhiteSpace(linkText))
+                        {
+                            linkText = destination.ToString();
+                        }
+
+                        footer.Value = new WebLinkTextElement(linkText, destination);
+                    }
+                }
+            }
+
+            return ChangeLogTaskResult.Success;
+        }
+    }
+}

--- a/src/ChangeLog/Tasks/ParseWebLinksTask.cs
+++ b/src/ChangeLog/Tasks/ParseWebLinksTask.cs
@@ -7,7 +7,7 @@ using Grynwald.ChangeLog.Pipeline;
 namespace Grynwald.ChangeLog.Tasks
 {
     /// <summary>
-    /// Detects footer values that are web links.
+    /// Detects footer values that are web (http/https) links.
     /// When a valid url is found, replaces  the footer's value (see <see cref="ChangeLogEntryFooter.Value"/>) with a <see cref="WebLinkTextElement"/>.
     /// </summary>
     [AfterTask(typeof(ParseCommitsTask))]
@@ -21,7 +21,7 @@ namespace Grynwald.ChangeLog.Tasks
             {
                 if (footer.Value is PlainTextElement plainText &&
                    Uri.TryCreate(plainText.Text, UriKind.Absolute, out var uri) &&
-                   IsWebLink(uri))
+                   uri.IsWebLink())
                 {
                     footer.Value = new WebLinkTextElement(plainText.Text, uri);
                 }
@@ -30,11 +30,5 @@ namespace Grynwald.ChangeLog.Tasks
             return ChangeLogTaskResult.Success;
         }
 
-        private bool IsWebLink(Uri uri) => uri.Scheme.ToLower() switch
-        {
-            "http" => true,
-            "https" => true,
-            _ => false
-        };
     }
 }

--- a/src/ChangeLog/_Extensions/UriExtensions.cs
+++ b/src/ChangeLog/_Extensions/UriExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Grynwald.ChangeLog
+{
+    internal static class UriExtensions
+    {
+        public static bool IsWebLink(this Uri uri) => uri.Scheme.ToLower() switch
+        {
+            "http" => true,
+            "https" => true,
+            _ => false
+        };
+    }
+}


### PR DESCRIPTION
When a footer's value is a valid Markdown link which's destination is a http or https address, replace the footer value with a link in the output.

See-Also: [Automatic References - Markdown Links](https://github.com/ap0llo/changelog/blob/master/docs/auto-references.md#markdown-links)
