### PR TITLE
chore: Reduce logging level for commit message overrides

### DIFF
--- a/src/ChangeLog/Tasks/LoadMessageOverridesFromFileSystemTask.cs
+++ b/src/ChangeLog/Tasks/LoadMessageOverridesFromFileSystemTask.cs
@@ -49,7 +49,7 @@ namespace Grynwald.ChangeLog.Tasks
         {
             if (m_OverrideMessages.Value.TryGetValue(commit.Id, out message))
             {
-                m_Logger.LogInformation($"Commit message for commit '{commit.Id}' was overridden through filesystem. Using message from filesystem instead of commit message.");
+                m_Logger.LogDebug($"Commit message for commit '{commit.Id}' was overridden through filesystem. Using message from filesystem instead of commit message.");
                 return true;
             }
 

--- a/src/ChangeLog/Tasks/LoadMessageOverridesFromGitNotesTask.cs
+++ b/src/ChangeLog/Tasks/LoadMessageOverridesFromGitNotesTask.cs
@@ -33,7 +33,7 @@ namespace Grynwald.ChangeLog.Tasks
 
             if (notes.Any())
             {
-                m_Logger.LogInformation($"Commit message for commit '{commit.Id}' was overridden through git-notes. Using message from git-notes instead of commit message.");
+                m_Logger.LogDebug($"Commit message for commit '{commit.Id}' was overridden through git-notes. Using message from git-notes instead of commit message.");
                 message = notes.Single().Message;
                 return true;
             }


### PR DESCRIPTION
Do not log every commit message override as "Information" log message but only as "Debug" message.
This makes the log output more readable/concise when using the default log level
