### PR TITLE
[WIP]feat(github): Repository file references

### DIFF
--- a/src/ChangeLog.Test/Integrations/GitHub/GitHubFileReferenceTextElementTest.cs
+++ b/src/ChangeLog.Test/Integrations/GitHub/GitHubFileReferenceTextElementTest.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Grynwald.ChangeLog.Integrations.GitHub;
+using Xunit;
+
+namespace Grynwald.ChangeLog.Test.Integrations.GitHub
+{
+    /// <summary>
+    /// Tests for <see cref="GitHubFileReferenceTextElement"/>
+    /// </summary>
+    public class GitHubFileReferenceTextElementTest
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("\t")]
+        public void Text_must_not_be_null_or_whitespace(string text)
+        {
+            // ARRANGE
+
+            // ACT 
+            var ex = Record.Exception(() => new GitHubFileReferenceTextElement(
+                text: text,
+                uri: new("http://example.com"),
+                relativePath: "relativePath"
+            ));
+
+            // ASSERT
+            var argumentException = Assert.IsType<ArgumentException>(ex);
+            Assert.Equal("text", argumentException.ParamName);
+        }
+
+        [Fact]
+        public void Uri_must_not_be_null()
+        {
+            // ARRANGE
+
+            // ACT 
+            var ex = Record.Exception(() => new GitHubFileReferenceTextElement(
+                text: "some text",
+                uri: null!,
+                relativePath: "relativePath"
+            ));
+
+            // ASSERT
+            var argumentNullException = Assert.IsType<ArgumentNullException>(ex);
+            Assert.Equal("uri", argumentNullException.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("\t")]
+        public void RelativePath_must_not_be_null_or_whitespace(string relativePath)
+        {
+            // ARRANGE
+
+            // ACT 
+            var ex = Record.Exception(() => new GitHubFileReferenceTextElement(
+                text: "Some Text",
+                uri: new("http://example.com"),
+                relativePath: relativePath
+            ));
+
+            // ASSERT
+            var argumentException = Assert.IsType<ArgumentException>(ex);
+            Assert.Equal("relativePath", argumentException.ParamName);
+        }
+    }
+}

--- a/src/ChangeLog.Test/Integrations/GitHub/_Helpers/GitHubClientMock.cs
+++ b/src/ChangeLog.Test/Integrations/GitHub/_Helpers/GitHubClientMock.cs
@@ -13,11 +13,13 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitHub
 
             public Mock<IRepositoryCommitsClient> Commit { get; } = new(MockBehavior.Strict);
 
+            public Mock<IRepositoryContentsClient> Content { get; } = new(MockBehavior.Strict);
+
 
             public RepositoriesClientMock()
             {
                 m_Mock.Setup(x => x.Commit).Returns(Commit.Object);
-
+                m_Mock.Setup(x => x.Content).Returns(Content.Object);
             }
         }
 

--- a/src/ChangeLog.Test/Integrations/GitHub/_Helpers/OctokitMockExtensions.cs
+++ b/src/ChangeLog.Test/Integrations/GitHub/_Helpers/OctokitMockExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Net;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Moq;
 using Moq.Language.Flow;
@@ -56,6 +58,30 @@ namespace Grynwald.ChangeLog.Test.Integrations.GitHub
         public static IReturnsResult<IPullRequestsClient> ThrowsNotFound(this ISetup<IPullRequestsClient, Task<PullRequest>> setup)
         {
             return setup.ThrowsAsync(new NotFoundException("Not found", HttpStatusCode.NotFound));
+        }
+
+        public static ISetup<IRepositoryContentsClient, Task<IReadOnlyList<RepositoryContent>>> SetupGetAllContents(this Mock<IRepositoryContentsClient> mock)
+        {
+            return mock.Setup(x => x.GetAllContents(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+        }
+
+        public static IReturnsResult<IRepositoryContentsClient> ThrowsNotFound(this ISetup<IRepositoryContentsClient, Task<IReadOnlyList<RepositoryContent>>> setup)
+        {
+            return setup.ThrowsAsync(new NotFoundException("Not found", HttpStatusCode.NotFound));
+        }
+
+        public static IReturnsResult<IRepositoryContentsClient> ReturnsTestRepositoryContent(
+            this ISetup<IRepositoryContentsClient, Task<IReadOnlyList<RepositoryContent>>> setup,
+            params TestRepositoryContent[] files)
+        {
+            return setup.ReturnsAsync((string _, string _, string _) => files);
+        }
+
+        public static IReturnsResult<IRepositoryContentsClient> ReturnsTestRepositoryContent(
+          this ISetup<IRepositoryContentsClient, Task<IReadOnlyList<RepositoryContent>>> setup,
+          IEnumerable<TestRepositoryContent> files)
+        {
+            return setup.ReturnsAsync((string _, string _, string _) => files.ToList());
         }
     }
 }

--- a/src/ChangeLog.Test/Integrations/GitHub/_Helpers/TestRepositoryContent.cs
+++ b/src/ChangeLog.Test/Integrations/GitHub/_Helpers/TestRepositoryContent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Octokit;
+
+namespace Grynwald.ChangeLog.Test.Integrations.GitHub
+{
+    public class TestRepositoryContent : RepositoryContent
+    {
+        public Uri HtmlUri => new Uri(HtmlUrl);
+
+        public TestRepositoryContent(string htmlUrl, string? content)
+        {
+            HtmlUrl = htmlUrl;
+
+            var encodedContent = content is null
+                ? null
+                : Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(content)); ;
+
+            // No really a good idea but probably okay for test code
+            typeof(RepositoryContent)
+                .GetProperty(nameof(EncodedContent))!
+                .SetMethod!
+                .Invoke(this, new[] { encodedContent });
+        }
+    }
+}

--- a/src/ChangeLog/Integrations/GitHub/GitHubFileReferenceTextElement.cs
+++ b/src/ChangeLog/Integrations/GitHub/GitHubFileReferenceTextElement.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Grynwald.ChangeLog.Model.Text;
+
+namespace Grynwald.ChangeLog.Integrations.GitHub
+{
+    /// <summary>
+    /// A <see cref="ITextElement"/> that references a file in a GitHub repository
+    /// </summary>
+    internal sealed class GitHubFileReferenceTextElement : ITextElement, IWebLinkTextElement
+    {
+        /// <inheritdoc />
+        public string Text { get; }
+
+        /// <inheritdoc />
+        public TextStyle Style => TextStyle.None;
+
+        /// <inheritdoc />
+        public Uri Uri { get; }
+
+        /// <summary>
+        /// Gets the relative path of the file within the GitHub repository.
+        /// </summary>
+        public string RelativePath { get; }
+
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="GitHubReferenceTextElement"/>.
+        /// </summary>
+        public GitHubFileReferenceTextElement(string text, Uri uri, string relativePath)
+        {
+            if (String.IsNullOrWhiteSpace(text))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(text));
+
+            if (String.IsNullOrWhiteSpace(relativePath))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(relativePath));
+
+            Text = text;
+            Uri = uri ?? throw new ArgumentNullException(nameof(uri));
+            RelativePath = relativePath;
+        }
+    }
+}


### PR DESCRIPTION
When the GitHub integration is enabled and a footer value is a relative path to a file that exists in the repository (in the default branch), convert the footer into a link to that file in the GitHub Web UI


### TODOs

- [x] Create link when footer value is relative path
- [ ] Create link when footer value is Markdown link with relative path
- [ ] Get title of document (for supported formats)?
- [ ] Support anchor links and line number links 
- [ ] Update documentation
