### PR TITLE
fix: Escape html tags in change log entry titles

### DIFF
--- a/src/ChangeLog.Test/Templates/TemplateTest.cs
+++ b/src/ChangeLog.Test/Templates/TemplateTest.cs
@@ -604,5 +604,39 @@ namespace Grynwald.ChangeLog.Test.Templates
 
             Approve(changeLog, config);
         }
+
+        [Fact]
+        public void ChangeLog_is_converted_to_expected_Output_23()
+        {
+            // HTML is entry titles is escaped 
+
+            var versionChangeLog = GetSingleVersionChangeLog(
+                "1.2.3",
+                null,
+                GetChangeLogEntry(
+                    scope: "api",
+                    type: "feat",
+                    summary: "Some change with <code> tag in title",
+                    body: new[] { "Content with <code> tag " },
+                    footers: new[]
+                    {
+                        new ChangeLogEntryFooter(new CommitMessageFooterName("See-Also"), new PlainTextElement("Text with <code> tag"))
+                    }
+                ),
+                GetChangeLogEntry(
+                    type: "feat",
+                    summary: "Some other change with <code> tag in title",
+                    body: new[] { "Content with <code> tag " },
+                    footers: new[]
+                    {
+                        new ChangeLogEntryFooter(new CommitMessageFooterName("See-Also"), new PlainTextElement("Text with <code> tag"))
+                    }
+                )
+            );
+
+            var changeLog = new ApplicationChangeLog() { versionChangeLog };
+
+            Approve(changeLog);
+        }
     }
 }

--- a/src/ChangeLog.Test/Templates/_referenceResults/DefaultTemplateTest.ChangeLog_is_converted_to_expected_Output_23.approved.txt
+++ b/src/ChangeLog.Test/Templates/_referenceResults/DefaultTemplateTest.ChangeLog_is_converted_to_expected_Output_23.approved.txt
@@ -1,0 +1,21 @@
+﻿# Change Log
+
+## 1.2.3
+
+### New Features
+
+- [**api:** Some change with &lt;code&gt; tag in title](#changelog-heading-0398ff29cc80d82071c735f75aea7d7ab8bbf9a3)
+- [Some other change with &lt;code&gt; tag in title](#changelog-heading-fecc81adb3c0389ded66e848b1cfd904fd7d7e5b)
+
+### Details
+
+#### <a id="changelog-heading-0398ff29cc80d82071c735f75aea7d7ab8bbf9a3"></a> **api:** Some change with &lt;code&gt; tag in title
+
+Content with &lt;code&gt; tag 
+- See Also: Text with &lt;code&gt; tag
+
+#### <a id="changelog-heading-fecc81adb3c0389ded66e848b1cfd904fd7d7e5b"></a> Some other change with &lt;code&gt; tag in title
+
+Content with &lt;code&gt; tag 
+- See Also: Text with &lt;code&gt; tag
+

--- a/src/ChangeLog.Test/Templates/_referenceResults/GitHubReleaseTemplateTest.ChangeLog_is_converted_to_expected_Output_23.approved.txt
+++ b/src/ChangeLog.Test/Templates/_referenceResults/GitHubReleaseTemplateTest.ChangeLog_is_converted_to_expected_Output_23.approved.txt
@@ -1,0 +1,17 @@
+﻿## New Features
+
+- [**api:** Some change with &lt;code&gt; tag in title](#changelog-heading-0398ff29cc80d82071c735f75aea7d7ab8bbf9a3)
+- [Some other change with &lt;code&gt; tag in title](#changelog-heading-fecc81adb3c0389ded66e848b1cfd904fd7d7e5b)
+
+## Details
+
+### <a id="changelog-heading-0398ff29cc80d82071c735f75aea7d7ab8bbf9a3"></a> **api:** Some change with &lt;code&gt; tag in title
+
+Content with &lt;code&gt; tag 
+- See Also: Text with &lt;code&gt; tag
+
+### <a id="changelog-heading-fecc81adb3c0389ded66e848b1cfd904fd7d7e5b"></a> Some other change with &lt;code&gt; tag in title
+
+Content with &lt;code&gt; tag 
+- See Also: Text with &lt;code&gt; tag
+

--- a/src/ChangeLog.Test/Templates/_referenceResults/GitLabReleaseTemplateTest.ChangeLog_is_converted_to_expected_Output_23.approved.txt
+++ b/src/ChangeLog.Test/Templates/_referenceResults/GitLabReleaseTemplateTest.ChangeLog_is_converted_to_expected_Output_23.approved.txt
@@ -1,0 +1,17 @@
+﻿#### New Features
+
+- [**api:** Some change with &lt;code&gt; tag in title](#api-some-change-with-ltcodegt-tag-in-title)
+- [Some other change with &lt;code&gt; tag in title](#some-other-change-with-ltcodegt-tag-in-title)
+
+#### Details
+
+##### **api:** Some change with &lt;code&gt; tag in title
+
+Content with &lt;code&gt; tag 
+- See Also: Text with &lt;code&gt; tag
+
+##### Some other change with &lt;code&gt; tag in title
+
+Content with &lt;code&gt; tag 
+- See Also: Text with &lt;code&gt; tag
+

--- a/src/ChangeLog.Test/Templates/_referenceResults/HtmlTemplateTest.ChangeLog_is_converted_to_expected_Output_23.approved.txt
+++ b/src/ChangeLog.Test/Templates/_referenceResults/HtmlTemplateTest.ChangeLog_is_converted_to_expected_Output_23.approved.txt
@@ -1,0 +1,245 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Change Log</title>
+    <style type="text/css">
+        * {
+            margin: 0;
+        }
+        
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: #F9FAFB;
+        }
+        
+        code {
+            font-family: Consolas, 'Courier New', Courier, monospace;
+        }
+        
+        
+        h1 {
+            font-size: 36px;
+            font-weight: 500;
+        
+        }
+        h2 {
+            font-size: 28px;
+            font-weight: 500;
+        }
+        h3 {
+            font-size: 20px;
+            font-weight: 500;
+        }
+        h4 {
+            font-size: 18px;
+            font-weight: 500;
+        }
+        ul li {
+            margin: 2px;
+        }
+        
+        a {
+            color: #0190df;
+        }
+        
+        a:hover {
+            color:#015f93
+        }
+        
+        p {
+            margin-top: 4px;
+            margin-bottom: 6px;
+        }
+        
+        .changelog {
+            margin-left: auto;
+            margin-right: auto;
+            margin-bottom: 64px;
+            width: 95%;
+        }
+        
+        @media only screen and (min-width: 768px) {
+          .changelog {
+            width: 80%;
+          }
+        }
+        
+        @media only screen and (min-width: 1700px) {
+          .changelog {
+            width: 70%;
+          }
+        }
+        
+        .changelog-toc {
+            margin-top: 8px;
+            padding: 8px;
+        }
+        
+        .changelog-toc-header h2 {
+            font-size: 22px;
+            margin: 0
+        }
+        
+        .changelog-toc-content {
+            margin: 8px
+        }
+        
+        
+        .changelog-version {
+            margin-top: 36px;
+            background-color: white;
+            border: 1px solid gray;
+            border-radius: 2px;
+            box-shadow:  0 .5em 1em -.125em #0a0a0a1a,0 0 0 1px #0a0a0a05;;
+        }
+        
+        .changelog-version:first-child {
+            margin-top: 18px;
+        }
+        
+        .changelog-header {
+            padding-top: 20px;
+        }
+        
+        .changelog-version-content {
+            padding: 16px;
+        }
+        
+        .changelog-version-content h2,
+        .changelog-version-content h3,
+        .changelog-version-content h4 {
+            margin-top: 4px;
+            margin-bottom: 4px;
+        }
+        .changelog-version-header {
+            padding: 8px 16px 8px 16px;
+            border-bottom: 1px solid gray;
+            background-color: #F1F3F5;
+        }
+        .changelog-version-header h2 {
+            font-weight: 550;
+        }
+        
+        
+        .changelog-entry {
+            padding: 8px;
+            border-bottom: 1px solid gray;
+        }
+        
+        .changelog-entry:last-child {
+            padding: 8px;
+            border-bottom: none;
+        }
+        
+        .changelog-entry-content {
+            font-size: 15.5px;
+            padding-top: 6px;
+            padding-bottom: 6px;
+        }
+        
+        .changelog-entry-content ul {
+            margin: 16px 0 0 0;
+        }
+        
+        .changelog-entry-list,
+        .changelog-breakingchanges-list{
+            margin-top: 20px;
+        }
+        .changelog-version-details {
+            margin-top: 32px;
+        }
+        
+
+    </style>
+</head>
+<body>
+    <div class="changelog">
+    
+        <div class="changelog-header">
+            <h1>Change Log</h1>
+        </div>
+    
+        
+    
+        <main class="changelog-content">
+            <div class="changelog-version">
+            
+                <div class="changelog-version-header">
+                    <h2 id="1.2.3">1.2.3</h2>
+                </div>
+            
+                <div class="changelog-version-content">
+                    <div class="changelog-version-summary">
+                    
+                        <div class="changelog-entry-list">
+                        
+                            <div class="changelog-entry-list-header">
+                                <h3>New Features</h3>
+                            </div>
+                        
+                            <div class="changelog-entry-list-content">
+                                <ul>
+                                    <li><a href="#0398ff2"><b>api:</b> Some change with &lt;code&gt; tag in title</a></li>
+                                    <li><a href="#fecc81a">Some other change with &lt;code&gt; tag in title</a></li>
+                                </ul>
+                            </div>
+                        
+                        </div>
+                    
+                        
+                    
+                    </div>
+                    
+                    <div class="changelog-version-details">
+                    
+                        <div class="changelog-version-details-header">
+                            <h3>Details</h3>
+                        </div>
+                    
+                        <div class="changelog-version-details-content">
+                            <div class="changelog-entry">
+                            
+                                <div class="changelog-entry-header">
+                                    <h4 id="0398ff2"><b>api:</b> Some change with &lt;code&gt; tag in title</h4>
+                                </div>
+                            
+                                <div class="changelog-entry-content">
+                            
+                            
+                                    <p>Content with &lt;code&gt; tag </p>
+                            
+                                    <ul>
+                                        <li>See Also: Text with &lt;code&gt; tag</li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <div class="changelog-entry">
+                            
+                                <div class="changelog-entry-header">
+                                    <h4 id="fecc81a">Some other change with &lt;code&gt; tag in title</h4>
+                                </div>
+                            
+                                <div class="changelog-entry-content">
+                            
+                            
+                                    <p>Content with &lt;code&gt; tag </p>
+                            
+                                    <ul>
+                                        <li>See Also: Text with &lt;code&gt; tag</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    
+                    </div>
+                </div>
+            
+            </div>
+        </main>
+    
+    </div>
+</body>
+</html>

--- a/src/ChangeLog/Templates/Default/_Resources/helpers/entry-title.scriban-txt
+++ b/src/ChangeLog/Templates/Default/_Resources/helpers/entry-title.scriban-txt
@@ -1,5 +1,5 @@
 ﻿{{~ if $.entry.has_scope ~}}
     {{~ ~}}**{{~ html.escape($.entry.scope_display_name) ~}}:** {{ html.escape($.entry.summary) ~}}
 {{~ else ~}}
-    {{~ $.entry.summary ~}}
+    {{~ html.escape($.entry.summary) ~}}
 {{~ end ~}}

--- a/src/ChangeLog/Templates/Html/_Resources/helpers/entry-title.scriban-html
+++ b/src/ChangeLog/Templates/Html/_Resources/helpers/entry-title.scriban-html
@@ -1,5 +1,5 @@
 ﻿{{~ if $.entry.has_scope ~}}
     {{~ ~}}<b>{{~ html.escape($.entry.scope_display_name) ~}}:</b> {{ html.escape($.entry.summary) ~}}
 {{~ else ~}}
-    {{~ $.entry.summary ~}}
+    {{~ html.escape($.entry.summary) ~}}
 {{~ end ~}}


### PR DESCRIPTION
If the title of a change log entry contains a HTML tag (e.g. &lt;code&gt;), escape the element in the output of all Markdown templates and the Html template