### PR TITLE
fix: Fix between commits and versions

### DIFF
--- a/src/ChangeLog.Test/TestGitIds.cs
+++ b/src/ChangeLog.Test/TestGitIds.cs
@@ -11,5 +11,8 @@ namespace Grynwald.ChangeLog.Test
         public static readonly GitId Id2 = new GitId("efgh5678efgh5678efgh5678efgh5678efgh5678", "efgh567");
         public static readonly GitId Id3 = new GitId("ijkl9101ijkl9101ijkl9101ijkl9101ijkl9101", "ijkl910");
         public static readonly GitId Id4 = new GitId("mnop1234mnop1234mnop1234mnop1234mnop1234", "mnop123");
+        public static readonly GitId Id5 = new GitId("qrst5679qrst5679qrst5679qrst5679qrst5679", "qrst5679");
+        public static readonly GitId Id6 = new GitId("uvwx0123uvwx0123uvwx0123uvwx0123uvwx0123", "uvwx0123");
+        public static readonly GitId Id7 = new GitId("yzab4567yzab4567yzab4567yzab4567yzab4567", "yzab4567");
     }
 }


### PR DESCRIPTION
An error in the way the commits included in a specific version was flawed causing a crash because the same commit was included in multiple versions.

For any version, changelog determines the commits that belong to that version by getting all commits reachable from that version's latest commit and excluding the commits included in the previous version.
Up until now, changelog was only examining the previous version, not all previous versions, which can lead to an error in certain git repositories.

Consider a git history with 3 versions (N, N-1 and N-2) with the following commit graph:


```txt
(Commit 4)  * [tag: v1.2] (version N)
            |                               (Commit 7) * [tag v1.1] (version N-1)
(Commit 3)  *                                          |
            |                               (Commit 6) *
            |                                          |
(Commit 2)  * [tag: v1.0] (version N-2)                |
            |                               (Commit 5) *
            |                                          |
(Commit 1)  *------------------------------------------+
            |
            |
```

When determining the commits for version N, changelog was only checking for the commits of version N-1.
Since Commit 2, is reachable from version N and N-2 but not from N-1, Commit 2 was included in both version N and N-2.

With this fix, all previous versions will be evaluated to determine the commits.
In the example above, the mapping between versions and commits will be as follows:

- Version 1.2 includes "Commit 3" and "Commit 4"
- Version 1.1 includes "Commit 5", "Commit 6" and "Commit 7"
- Version 1.0 includes "Commit 1" and "Commit 2"
